### PR TITLE
[AN] feat: 모험이 끝났을 때 서버에게 모험이 종료 됐음을 알려주는 기능 구현

### DIFF
--- a/android/app/src/main/java/com/now/naaga/data/mapper/AdventureMapper.kt
+++ b/android/app/src/main/java/com/now/naaga/data/mapper/AdventureMapper.kt
@@ -3,6 +3,7 @@ package com.now.naaga.data.mapper
 import com.now.domain.model.Adventure
 import com.now.domain.model.AdventureStatus
 import com.now.naaga.data.remote.dto.AdventureDto
+import com.now.naaga.data.remote.dto.EndedAdventureDto
 
 fun AdventureDto.toDomain(): Adventure {
     return Adventure(
@@ -10,4 +11,8 @@ fun AdventureDto.toDomain(): Adventure {
         destination = destinationDto.toDomain(),
         adventureStatus = AdventureStatus.getStatus(adventureStatus),
     )
+}
+
+fun EndedAdventureDto.toDomain(): AdventureStatus {
+    return AdventureStatus.getStatus(adventureStatus)
 }

--- a/android/app/src/main/java/com/now/naaga/data/remote/dto/EndedAdventureDto.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/dto/EndedAdventureDto.kt
@@ -1,0 +1,9 @@
+package com.now.naaga.data.remote.dto
+
+import kotlinx.serialization.SerialName
+
+data class EndedAdventureDto(
+    val id: Long,
+    @SerialName("gameStatus")
+    val adventureStatus: String,
+)

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AdventureService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AdventureService.kt
@@ -2,6 +2,7 @@ package com.now.naaga.data.remote.retrofit.service
 
 import com.now.naaga.data.remote.dto.AdventureDto
 import com.now.naaga.data.remote.dto.CoordinateDto
+import com.now.naaga.data.remote.dto.EndedAdventureDto
 import retrofit2.Call
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -24,5 +25,5 @@ interface AdventureService {
     fun endGame(
         @Path("gameId") gameId: Long,
         @Body coordinateDto: CoordinateDto,
-    ): Call<Unit>
+    ): Call<EndedAdventureDto>
 }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAdventureRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAdventureRepository.kt
@@ -1,13 +1,18 @@
 package com.now.naaga.data.repository
 
 import com.now.domain.model.Adventure
+import com.now.domain.model.AdventureStatus
 import com.now.domain.model.Coordinate
 import com.now.domain.repository.AdventureRepository
 import com.now.naaga.data.NaagaThrowable
+import com.now.naaga.data.mapper.toDomain
 import com.now.naaga.data.mapper.toDto
+import com.now.naaga.data.remote.dto.EndedAdventureDto
 import com.now.naaga.data.remote.retrofit.ERROR_500
 import com.now.naaga.data.remote.retrofit.ERROR_NOT_400_500
 import com.now.naaga.data.remote.retrofit.ServicePool
+import com.now.naaga.data.remote.retrofit.ServicePool.adventureService
+import com.now.naaga.data.remote.retrofit.fetchNaagaResponse
 import com.now.naaga.data.remote.retrofit.getFailureDto
 import com.now.naaga.data.remote.retrofit.isFailure400
 import com.now.naaga.data.remote.retrofit.isFailure500
@@ -54,8 +59,16 @@ class DefaultAdventureRepository : AdventureRepository {
     override fun endAdventure(
         adventureId: Long,
         coordinate: Coordinate,
-        callback: (Result<Unit>) -> Unit,
+        callback: (Result<AdventureStatus>) -> Unit,
     ) {
-        // TODO("Not yet implemented")
+        val call: Call<EndedAdventureDto> = adventureService.endGame(adventureId, coordinate.toDto())
+        call.fetchNaagaResponse(
+            { AdventureEndDto ->
+                if (AdventureEndDto != null) {
+                    callback(Result.success(AdventureEndDto.toDomain()))
+                }
+            },
+            { callback(Result.failure(NaagaThrowable.ServerConnectFailure())) },
+        )
     }
 }

--- a/android/app/src/main/java/com/now/naaga/data/repository/MockAdventureRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/MockAdventureRepository.kt
@@ -2,6 +2,7 @@ package com.now.naaga.data.repository
 
 import com.now.domain.model.Adventure
 import com.now.domain.model.AdventureStatus
+import com.now.domain.model.AdventureStatus.DONE
 import com.now.domain.model.Coordinate
 import com.now.domain.model.Destination
 import com.now.domain.repository.AdventureRepository
@@ -22,9 +23,9 @@ class MockAdventureRepository : AdventureRepository {
     override fun endAdventure(
         adventureId: Long,
         coordinate: Coordinate,
-        callback: (Result<Unit>) -> Unit,
+        callback: (Result<AdventureStatus>) -> Unit,
     ) {
-        TODO("Not yet implemented")
+        callback(Result.success(DONE))
     }
 
     companion object {

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -84,6 +84,7 @@ class OnAdventureActivity : AppCompatActivity(), OnMapReadyCallback {
         naverMap.addOnLocationChangeListener { location ->
             viewModel.calculateDistance(Coordinate(location.latitude, location.longitude))
             viewModel.checkArrived(Coordinate(location.latitude, location.longitude))
+            setBinding(Coordinate(location.latitude, location.longitude))
         }
     }
 
@@ -95,6 +96,10 @@ class OnAdventureActivity : AppCompatActivity(), OnMapReadyCallback {
     private fun setFollowMode() {
         naverMap.locationSource = locationSource
         naverMap.locationTrackingMode = LocationTrackingMode.Follow
+    }
+
+    private fun setBinding(coordinate: Coordinate) {
+        binding.currentMyCoordinate = coordinate
     }
 
     private fun startObserving() {

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -1,5 +1,6 @@
 package com.now.naaga.presentation.onadventure
 
+import android.content.Intent
 import android.location.Location
 import android.os.Bundle
 import android.widget.Toast
@@ -19,6 +20,7 @@ import com.now.domain.model.Coordinate
 import com.now.naaga.R
 import com.now.naaga.data.repository.DefaultAdventureRepository
 import com.now.naaga.databinding.ActivityOnAdventureBinding
+import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -101,6 +103,7 @@ class OnAdventureActivity : AppCompatActivity(), OnMapReadyCallback {
         }
         viewModel.status.observe(this) { status ->
             stopAdventure(status)
+            onStatusChanged(status)
         }
         viewModel.adventureId.observe(this) { adventureId ->
             viewModel.fetchDestination(adventureId)
@@ -140,6 +143,20 @@ class OnAdventureActivity : AppCompatActivity(), OnMapReadyCallback {
             } else {
                 (fragment as DialogFragment).dialog?.show()
             }
+        }
+    }
+
+    private fun onStatusChanged(status: AdventureStatus) {
+        when (status) {
+            AdventureStatus.DONE -> {
+                Toast.makeText(this, getString(R.string.onAdventure_adventure_success), Toast.LENGTH_LONG).show()
+                startActivity(Intent(this, BeginAdventureActivity::class.java))
+                finish()
+            }
+            AdventureStatus.IN_PROGRESS -> {
+                Toast.makeText(this, getString(R.string.onAdventure_retry), Toast.LENGTH_LONG).show()
+            }
+            AdventureStatus.ERROR -> { stopAdventure(status) }
         }
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureViewModel.kt
@@ -76,4 +76,29 @@ class OnAdventureViewModel(
                 }
         }
     }
+
+    fun endAdventure(adventureId: Long, coordinate: Coordinate) {
+        adventureRepository.endAdventure(adventureId, coordinate, callback = { result ->
+            result
+                .onSuccess { adventureStatus -> _status.value = adventureStatus }
+                .onFailure { throwable ->
+                    when (throwable) {
+                        is NaagaThrowable.AuthenticationError ->
+                            _errorMessage.value =
+                                throwable.userMessage
+
+                        is NaagaThrowable.UserError -> _errorMessage.value = throwable.userMessage
+                        is NaagaThrowable.PlaceError -> _errorMessage.value = throwable.userMessage
+                        is NaagaThrowable.GameError -> _errorMessage.value = throwable.userMessage
+                        is NaagaThrowable.ServerConnectFailure ->
+                            _errorMessage.value =
+                                throwable.userMessage
+
+                        is NaagaThrowable.NaagaUnknownError ->
+                            _errorMessage.value =
+                                throwable.userMessage
+                    }
+                }
+        })
+    }
 }

--- a/android/app/src/main/res/layout/activity_on_adventure.xml
+++ b/android/app/src/main/res/layout/activity_on_adventure.xml
@@ -8,6 +8,10 @@
         <variable
             name="viewModel"
             type="com.now.naaga.presentation.onadventure.OnAdventureViewModel" />
+
+        <variable
+            name="CurrentMyCoordinate"
+            type="com.now.domain.model.Coordinate" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -34,7 +38,7 @@
             android:background="@drawable/rect_radius_small"
             android:backgroundTint="@color/selector_main_gray_purple"
             android:enabled="@{viewModel.isArrived}"
-            android:onClick="@{() -> viewModel.endAdventure()}"
+            android:onClick="@{() -> viewModel.endAdventure(viewModel.adventureId, CurrentMyCoordinate)}"
             android:fontFamily="@font/pretendard_bold"
             android:paddingHorizontal="28dp"
             android:paddingVertical="@dimen/space_default_medium"

--- a/android/app/src/main/res/layout/activity_on_adventure.xml
+++ b/android/app/src/main/res/layout/activity_on_adventure.xml
@@ -34,6 +34,7 @@
             android:background="@drawable/rect_radius_small"
             android:backgroundTint="@color/selector_main_gray_purple"
             android:enabled="@{viewModel.isArrived}"
+            android:onClick="@{() -> viewModel.endAdventure()}"
             android:fontFamily="@font/pretendard_bold"
             android:paddingHorizontal="28dp"
             android:paddingVertical="@dimen/space_default_medium"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -12,4 +12,6 @@
     <string name="on_adventure">모험 중</string>
     <string name="end_adventure">모험 종료</string>
     <string name="polaroid_description">이곳은 어디일까요?</string>
+    <string name="onAdventure_retry">아직 도착하지 못했어요.. 다시 도전해봐요!</string>
+    <string name="onAdventure_adventure_success">목적지를 찾는데 성공했어요!!</string>
 </resources>

--- a/android/domain/src/main/java/com/now/domain/repository/AdventureRepository.kt
+++ b/android/domain/src/main/java/com/now/domain/repository/AdventureRepository.kt
@@ -1,6 +1,7 @@
 package com.now.domain.repository
 
 import com.now.domain.model.Adventure
+import com.now.domain.model.AdventureStatus
 import com.now.domain.model.Coordinate
 
 interface AdventureRepository {
@@ -8,5 +9,9 @@ interface AdventureRepository {
 
     fun getAdventure(adventureId: Long, callback: (Result<Adventure>) -> Unit)
 
-    fun endAdventure(adventureId: Long, coordinate: Coordinate, callback: (Result<Unit>) -> Unit)
+    fun endAdventure(
+        adventureId: Long,
+        coordinate: Coordinate,
+        callback: (Result<AdventureStatus>) -> Unit,
+    )
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #46 

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [X] 서버 통신을 위한 EndedAdventureDto 객체 생성
- [X] AdventureRepository의 endAdventure의 구현체 작성
- [X] Retrofit을 사용해 도착 버튼 클릭 시 서버에게 모험 상태가 종료됐음을 알려주는 기능 추가
- [X] 목적지에 도착해 도착 버튼 클릭 후 모험 상태가 Done으로 바뀌면 사용자에게 메시지를 띄우고, BeginAdventure 액티비티로 이동시키는 기능 추가
- [X] 목적지에 도착해 도착 버튼 클릭했지만 모험 상태가 Done으로 바뀌지 않을 시, 사용자에게 한번 더 클릭해보라는 메시지를 띄워주는 기능 추가

## 🎯 리뷰 포인트
- Result를 이용해 Retrofit 통신을 했습니다. 서버에서 받아오는 Dto는 새롭게 생성했지만, 이를 기존에 있던 domain 객체인 AdventureStatus로 변환시키는 mapper를 사용해 Presentation 계층에서는 status만으로 분기를 처리할 수 있도록 구현했습니다.

## ⏳ 작업 시간
추정 시간:  1h
실제 시간:  1h 30m
이유: 서버에서 어떤 Dto로 데이터를 받아올 지 여러가지 방법들을 생각하느라 시간이 걸렸습니다.