### PR TITLE
[AN] feat: AdventureHistoryActivity 구현

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,9 +16,6 @@
         android:theme="@style/Theme.Naaga"
         android:usesCleartextTraffic="true"
         tools:targetApi="33">
-        <activity
-            android:name=".presentation.upload.UploadActivity"
-            android:exported="false" />
 
         <meta-data
             android:name="com.naver.maps.map.CLIENT_ID"
@@ -30,16 +27,21 @@
             android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
         <activity
             android:name=".presentation.beginadventure.BeginAdventureActivity"
             android:exported="false" />
-
         <activity
             android:name=".presentation.onadventure.OnAdventureActivity"
+            android:exported="false" />
+        <activity
+            android:name=".presentation.adventurehistory.AdventureHistoryActivity"
+            android:exported="true" />
+        <activity
+            android:name=".presentation.upload.UploadActivity"
             android:exported="false" />
     </application>
 

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryActivity.kt
@@ -23,6 +23,7 @@ class AdventureHistoryActivity : AppCompatActivity() {
         initRecyclerView()
         viewModel.fetchHistories()
         startObserving()
+        setClickListeners()
     }
 
     private fun initViewModel() {
@@ -41,6 +42,12 @@ class AdventureHistoryActivity : AppCompatActivity() {
     private fun startObserving() {
         viewModel.places.observe(this) { places ->
             updateHistory(places)
+        }
+    }
+
+    private fun setClickListeners() {
+        binding.ivAdventureHistoryBack.setOnClickListener {
+            finish()
         }
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryActivity.kt
@@ -22,7 +22,7 @@ class AdventureHistoryActivity : AppCompatActivity() {
         initViewModel()
         initRecyclerView()
         viewModel.fetchHistories()
-        startObserving()
+        subscribeObserving()
         setClickListeners()
     }
 
@@ -39,7 +39,7 @@ class AdventureHistoryActivity : AppCompatActivity() {
         }
     }
 
-    private fun startObserving() {
+    private fun subscribeObserving() {
         viewModel.places.observe(this) { places ->
             updateHistory(places)
         }

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryActivity.kt
@@ -1,0 +1,38 @@
+package com.now.naaga.presentation.adventurehistory
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
+import com.now.naaga.databinding.ActivityAdventureHistoryBinding
+
+class AdventureHistoryActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityAdventureHistoryBinding
+    private lateinit var viewModel: AdventureHistoryViewModel
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityAdventureHistoryBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        initViewModel()
+        viewModel.fetchHistories()
+        startObserving()
+    }
+
+    private fun initViewModel() {
+        viewModel = ViewModelProvider(this)[AdventureHistoryViewModel::class.java]
+        binding.lifecycleOwner = this
+    }
+
+    private fun startObserving() {
+        viewModel.places.observe(this) { places ->
+        }
+    }
+
+    companion object {
+        fun getIntent(context: Context): Intent {
+            return Intent(context, AdventureHistoryActivity::class.java)
+        }
+    }
+}

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryActivity.kt
@@ -5,17 +5,22 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
+import com.now.domain.model.AdventureResult
 import com.now.naaga.databinding.ActivityAdventureHistoryBinding
+import com.now.naaga.presentation.adventurehistory.recyclerview.AdventureHistoryAdapter
 
 class AdventureHistoryActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAdventureHistoryBinding
     private lateinit var viewModel: AdventureHistoryViewModel
+
+    private val historyAdapter = AdventureHistoryAdapter()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityAdventureHistoryBinding.inflate(layoutInflater)
         setContentView(binding.root)
         initViewModel()
+        initRecyclerView()
         viewModel.fetchHistories()
         startObserving()
     }
@@ -25,9 +30,22 @@ class AdventureHistoryActivity : AppCompatActivity() {
         binding.lifecycleOwner = this
     }
 
+    private fun initRecyclerView() {
+        binding.rvAdventureHistoryVisitedPlaces.apply {
+            adapter = historyAdapter
+            itemAnimator = null
+            setHasFixedSize(true)
+        }
+    }
+
     private fun startObserving() {
         viewModel.places.observe(this) { places ->
+            updateHistory(places)
         }
+    }
+
+    private fun updateHistory(places: List<AdventureResult>) {
+        historyAdapter.submitList(places)
     }
 
     companion object {

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.now.domain.model.AdventureResult
-import com.now.domain.model.AdventureResultType.FAIL
 import com.now.domain.model.AdventureResultType.SUCCESS
 import com.now.domain.model.Coordinate
 import com.now.domain.model.Place
@@ -20,7 +19,7 @@ class AdventureHistoryViewModel : ViewModel() {
     }
 
     companion object {
-        val MOCK_ADVENTURE_HISTORY_DATA = listOf(
+        val MOCK_ADVENTURE_HISTORY_DATA = List(4) {
             AdventureResult(
                 id = 1,
                 gameId = 1,
@@ -40,47 +39,7 @@ class AdventureHistoryViewModel : ViewModel() {
                 raisedRank = 2,
                 beginTime = LocalDateTime.of(2023, 8, 1, 13, 30, 0),
                 endTime = LocalDateTime.of(2023, 8, 1, 14, 0, 0),
-            ),
-            AdventureResult(
-                id = 1,
-                gameId = 1,
-                destination = Place(
-                    id = 1,
-                    name = "선정릉 돌담길",
-                    coordinate = Coordinate(35.3094, 127.21389),
-                    image = "",
-                    description = "test",
-                ),
-                resultType = SUCCESS,
-                score = 130,
-                playTime = LocalTime.of(13, 30, 0),
-                distance = 300,
-                hintUses = 3,
-                tryCount = 2,
-                raisedRank = 2,
-                beginTime = LocalDateTime.of(2023, 8, 1, 13, 30, 0),
-                endTime = LocalDateTime.of(2023, 8, 1, 14, 0, 0),
-            ),
-            AdventureResult(
-                id = 1,
-                gameId = 1,
-                destination = Place(
-                    id = 1,
-                    name = "선정릉 돌담길",
-                    coordinate = Coordinate(35.3094, 127.21389),
-                    image = "",
-                    description = "test",
-                ),
-                resultType = FAIL,
-                score = 130,
-                playTime = LocalTime.of(13, 30, 0),
-                distance = 300,
-                hintUses = 3,
-                tryCount = 2,
-                raisedRank = 2,
-                beginTime = LocalDateTime.of(2023, 8, 1, 13, 30, 0),
-                endTime = LocalDateTime.of(2023, 8, 1, 14, 0, 0),
-            ),
-        )
+            )
+        }
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/AdventureHistoryViewModel.kt
@@ -1,0 +1,86 @@
+package com.now.naaga.presentation.adventurehistory
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.now.domain.model.AdventureResult
+import com.now.domain.model.AdventureResultType.FAIL
+import com.now.domain.model.AdventureResultType.SUCCESS
+import com.now.domain.model.Coordinate
+import com.now.domain.model.Place
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class AdventureHistoryViewModel : ViewModel() {
+    private val _places = MutableLiveData<List<AdventureResult>>()
+    val places: LiveData<List<AdventureResult>> = _places
+
+    fun fetchHistories() {
+        _places.value = MOCK_ADVENTURE_HISTORY_DATA
+    }
+
+    companion object {
+        val MOCK_ADVENTURE_HISTORY_DATA = listOf(
+            AdventureResult(
+                id = 1,
+                gameId = 1,
+                destination = Place(
+                    id = 1,
+                    name = "선정릉 돌담길",
+                    coordinate = Coordinate(35.3094, 127.21389),
+                    image = "",
+                    description = "test",
+                ),
+                resultType = SUCCESS,
+                score = 130,
+                playTime = LocalTime.of(13, 30, 0),
+                distance = 300,
+                hintUses = 3,
+                tryCount = 2,
+                raisedRank = 2,
+                beginTime = LocalDateTime.of(2023, 8, 1, 13, 30, 0),
+                endTime = LocalDateTime.of(2023, 8, 1, 14, 0, 0),
+            ),
+            AdventureResult(
+                id = 1,
+                gameId = 1,
+                destination = Place(
+                    id = 1,
+                    name = "선정릉 돌담길",
+                    coordinate = Coordinate(35.3094, 127.21389),
+                    image = "",
+                    description = "test",
+                ),
+                resultType = SUCCESS,
+                score = 130,
+                playTime = LocalTime.of(13, 30, 0),
+                distance = 300,
+                hintUses = 3,
+                tryCount = 2,
+                raisedRank = 2,
+                beginTime = LocalDateTime.of(2023, 8, 1, 13, 30, 0),
+                endTime = LocalDateTime.of(2023, 8, 1, 14, 0, 0),
+            ),
+            AdventureResult(
+                id = 1,
+                gameId = 1,
+                destination = Place(
+                    id = 1,
+                    name = "선정릉 돌담길",
+                    coordinate = Coordinate(35.3094, 127.21389),
+                    image = "",
+                    description = "test",
+                ),
+                resultType = FAIL,
+                score = 130,
+                playTime = LocalTime.of(13, 30, 0),
+                distance = 300,
+                hintUses = 3,
+                tryCount = 2,
+                raisedRank = 2,
+                beginTime = LocalDateTime.of(2023, 8, 1, 13, 30, 0),
+                endTime = LocalDateTime.of(2023, 8, 1, 14, 0, 0),
+            ),
+        )
+    }
+}

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/recyclerview/AdventureHistoryAdapter.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/recyclerview/AdventureHistoryAdapter.kt
@@ -1,0 +1,32 @@
+package com.now.naaga.presentation.adventurehistory.recyclerview
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import com.now.domain.model.AdventureResult
+import com.now.naaga.databinding.ItemHistoryBinding
+
+class AdventureHistoryAdapter : ListAdapter<AdventureResult, AdventureHistoryViewHolder>(historyDiff) {
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AdventureHistoryViewHolder {
+        val binding =
+            ItemHistoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return AdventureHistoryViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: AdventureHistoryViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    companion object {
+        val historyDiff = object : DiffUtil.ItemCallback<AdventureResult>() {
+            override fun areItemsTheSame(oldItem: AdventureResult, newItem: AdventureResult): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(oldItem: AdventureResult, newItem: AdventureResult): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/recyclerview/AdventureHistoryViewHolder.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/recyclerview/AdventureHistoryViewHolder.kt
@@ -1,0 +1,35 @@
+package com.now.naaga.presentation.adventurehistory.recyclerview
+
+import androidx.recyclerview.widget.RecyclerView
+import com.now.domain.model.AdventureResult
+import com.now.domain.model.AdventureResultType
+import com.now.naaga.R
+import com.now.naaga.databinding.ItemHistoryBinding
+
+class AdventureHistoryViewHolder(
+    private val binding: ItemHistoryBinding,
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(adventureResult: AdventureResult) {
+        binding.adventureResult = adventureResult
+        setPhoto(binding, adventureResult.resultType)
+        setName(binding, adventureResult)
+    }
+
+    private fun setPhoto(binding: ItemHistoryBinding, resultType: AdventureResultType) {
+        when (resultType) {
+            AdventureResultType.SUCCESS -> binding.ivAdventureHistoryStamp.setImageResource(R.drawable.ic_success)
+            AdventureResultType.FAIL -> binding.ivAdventureHistoryStamp.setImageResource(R.drawable.ic_fail)
+        }
+    }
+
+    private fun setName(binding: ItemHistoryBinding, adventureResult: AdventureResult) {
+        when (adventureResult.resultType) {
+            AdventureResultType.SUCCESS -> binding.tvAdventureHistoryName.text = adventureResult.destination.name
+            AdventureResultType.FAIL -> binding.tvAdventureHistoryName.text = DESTINATION_NAME_IN_FAILURE_CASE
+        }
+    }
+
+    companion object {
+        private const val DESTINATION_NAME_IN_FAILURE_CASE = "????"
+    }
+}

--- a/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/recyclerview/AdventureHistoryViewHolder.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventurehistory/recyclerview/AdventureHistoryViewHolder.kt
@@ -11,18 +11,18 @@ class AdventureHistoryViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
     fun bind(adventureResult: AdventureResult) {
         binding.adventureResult = adventureResult
-        setPhoto(binding, adventureResult.resultType)
-        setName(binding, adventureResult)
+        setPhoto(adventureResult.resultType)
+        setName(adventureResult)
     }
 
-    private fun setPhoto(binding: ItemHistoryBinding, resultType: AdventureResultType) {
+    private fun setPhoto(resultType: AdventureResultType) {
         when (resultType) {
             AdventureResultType.SUCCESS -> binding.ivAdventureHistoryStamp.setImageResource(R.drawable.ic_success)
             AdventureResultType.FAIL -> binding.ivAdventureHistoryStamp.setImageResource(R.drawable.ic_fail)
         }
     }
 
-    private fun setName(binding: ItemHistoryBinding, adventureResult: AdventureResult) {
+    private fun setName(adventureResult: AdventureResult) {
         when (adventureResult.resultType) {
             AdventureResultType.SUCCESS -> binding.tvAdventureHistoryName.text = adventureResult.destination.name
             AdventureResultType.FAIL -> binding.tvAdventureHistoryName.text = DESTINATION_NAME_IN_FAILURE_CASE

--- a/android/app/src/main/res/drawable/ic_arrow.xml
+++ b/android/app/src/main/res/drawable/ic_arrow.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="28dp"
+    android:viewportWidth="16"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M0.623,15.672L12.467,27.373C13.299,28.209 14.545,28.209 15.377,27.373C16.208,26.537 16.208,25.284 15.377,24.448L5.195,14L15.377,3.552C16.208,2.716 16.208,1.463 15.377,0.627C14.961,0.209 14.545,0 13.922,0C13.299,0 12.883,0.209 12.467,0.627L0.623,12.328C-0.208,13.373 -0.208,14.627 0.623,15.672C0.623,15.463 0.623,15.463 0.623,15.672Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/android/app/src/main/res/layout/activity_adventure_history.xml
+++ b/android/app/src/main/res/layout/activity_adventure_history.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".presentation.adventurehistory.AdventureHistoryActivity">
+
+
+        <ImageView
+            android:id="@+id/iv_adventureHistory_back"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_arrow" />
+
+        <TextView
+            android:id="@+id/tv_adventureHistory_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="16dp"
+            android:fontFamily="@font/pretendard_bold"
+            android:text="@string/history_title"
+            android:textColor="@color/white"
+            android:textSize="30sp"
+            app:layout_constraintStart_toEndOf="@id/iv_adventureHistory_back"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_adventureHistory_visitedPlaces"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="24dp"
+            android:layout_marginEnd="24dp"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_adventureHistory_back"
+            app:spanCount="2"
+            tools:listitem="@layout/item_history" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>
+

--- a/android/app/src/main/res/layout/item_history.xml
+++ b/android/app/src/main/res/layout/item_history.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+        <variable
+            name="adventureResult"
+            type="com.now.domain.model.AdventureResult" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/rect_radius_small"
+        android:layout_marginVertical="8dp"
+        android:layout_marginHorizontal="8dp"
+        android:backgroundTint="#BAFFFFFF">
+
+        <ImageView
+            android:id="@+id/iv_adventureHistory_photo"
+            android:layout_width="140dp"
+            android:layout_height="128dp"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginEnd="12dp"
+            android:scaleType="centerCrop"
+            android:src="@{adventureResult.destination.image}"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:srcCompat="@tools:sample/avatars" />
+
+        <TextView
+            android:id="@+id/tv_adventureHistory_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:fontFamily="@font/pretendard_bold"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/iv_adventureHistory_photo"
+            tools:text="선정릉 돌담길" />
+
+        <ImageView
+            android:id="@+id/iv_adventureHistory_stamp"
+            android:layout_width="76dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:adjustViewBounds="true"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_adventureHistory_name"
+            app:srcCompat="@drawable/ic_success" />
+
+        <TextView
+            android:id="@+id/tv_adventureHistory_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="28dp"
+            android:layout_marginEnd="12dp"
+            android:layout_marginBottom="12dp"
+            android:fontFamily="@font/pretendard_medium"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            android:text="@{adventureResult.beginTime.toLocalDate().toString()}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/iv_adventureHistory_stamp"
+            tools:text="2023.07.30" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/item_history.xml
+++ b/android/app/src/main/res/layout/item_history.xml
@@ -39,6 +39,8 @@
             android:fontFamily="@font/pretendard_bold"
             android:textColor="@color/black"
             android:textSize="16sp"
+            android:ellipsize="end"
+            android:maxLines="1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/iv_adventureHistory_photo"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -39,4 +39,6 @@
     <!-- CameraDialog-->
     <string name="cameraDialog_description">장소를 올리기 위해서는\n카메라 접근 권한이 필요해요!</string>
 
+    <!-- AdventureHistoryActivity -->
+    <string name="history_title">History</string>
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #64 

## 🛠️ 작업 내용
- [x] 모험기록을 띄워주는 뷰를 리사이클러뷰를 사용해 구현
- [x] 뒤로가기 버튼 구현

## 🎯 리뷰 포인트
리사이클러뷰를 사용해 모험기록을 띄워주는 뷰를 구현했습니다. 특히 ListAdapter를 사용해 아이템 변경애 용이하도록 구현했습니다. 그리고 최대한 데이터 바인딩을 사용하려고 했지만, 불가능한 부분은 viewHolder에 코드로 뷰가 변경되도록 구현하였습니다. ListAdapter는 처음 적용해 본 것이기 때문에 해당 부분들을 집중해서 봐주시면 좋을 것 같습니다. 
<img src="https://github.com/woowacourse-teams/2023-naaga/assets/83613106/1757ac3f-a128-4e7f-938f-360cd08a405e" width=300>

## ⏳ 작업 시간
추정 시간: 3h  
실제 시간: 5h  
이유: 어떤 Adapter를 사용할까 생각하다가 이번에 ListAdapter를 사용해보자고 결정해, 해당 어댑터에 대한 장점과 사용법에 대해 공부하고 체화시키느라 시간이 생각보다 더 걸렸습니다.
