### PR TITLE
[BE] feat: 게임 결과 조회 기능 구현

### DIFF
--- a/backend/src/main/java/com/now/naaga/game/application/GameService.java
+++ b/backend/src/main/java/com/now/naaga/game/application/GameService.java
@@ -5,9 +5,12 @@ import com.now.naaga.game.application.dto.FindGameByIdCommand;
 import com.now.naaga.game.application.dto.FindGameByStatusCommand;
 import com.now.naaga.game.application.dto.FinishGameCommand;
 import com.now.naaga.game.domain.Game;
+import com.now.naaga.game.domain.GameRecord;
+import com.now.naaga.game.domain.GameResult;
 import com.now.naaga.game.domain.GameStatus;
 import com.now.naaga.game.exception.GameException;
 import com.now.naaga.game.repository.GameRepository;
+import com.now.naaga.game.repository.GameResultRepository;
 import com.now.naaga.place.application.PlaceService;
 import com.now.naaga.place.domain.Place;
 import com.now.naaga.place.domain.Position;
@@ -17,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.now.naaga.game.exception.GameExceptionType.ALREADY_IN_PROGRESS;
 import static com.now.naaga.game.exception.GameExceptionType.NOT_EXIST;
@@ -27,14 +31,18 @@ public class GameService {
 
     private final GameRepository gameRepository;
 
+    private final GameResultRepository gameResultRepository;
+
     private final PlayerService playerService;
 
     private final PlaceService placeService;
 
     public GameService(final GameRepository gameRepository,
+                       final GameResultRepository gameResultRepository,
                        final PlayerService playerService,
                        final PlaceService placeService) {
         this.gameRepository = gameRepository;
+        this.gameResultRepository = gameResultRepository;
         this.playerService = playerService;
         this.placeService = placeService;
     }
@@ -74,5 +82,31 @@ public class GameService {
     public List<Game> findGamesByStatus(final FindGameByStatusCommand findGameByStatusCommand) {
         Player player = playerService.findPlayerById(findGameByStatusCommand.playerId());
         return gameRepository.findByPlayerIdAndGameStatus(player.getId(), findGameByStatusCommand.gameStatus());
+    }
+
+    @Transactional(readOnly = true)
+    public GameResult findGameResultByGameId(final Long gameId) {
+        List<GameResult> gameResultsByGameId = gameResultRepository.findByGameId(gameId);
+
+        if (gameResultsByGameId.isEmpty()) {
+            throw new IllegalArgumentException("해당게임의 게임결과가 존재하지 않습니다.");
+        }
+
+        return gameResultsByGameId.get(0);
+    }
+
+    @Transactional(readOnly = true)
+    public GameRecord findGameResult(final Long gameId) {
+        final GameResult gameResult = findGameResultByGameId(gameId);
+        return GameRecord.from(gameResult);
+    }
+
+    @Transactional(readOnly = true)
+    public List<GameRecord> findAllGameResult() {
+        final List<GameResult> gameResults = gameResultRepository.findAll();
+        gameResults.sort((gr1, gr2) -> gr2.getCreatedAt().compareTo(gr1.getCreatedAt()));
+        return gameResults.stream()
+                .map(GameRecord::from)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/com/now/naaga/game/application/GameService.java
+++ b/backend/src/main/java/com/now/naaga/game/application/GameService.java
@@ -22,8 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.now.naaga.game.exception.GameExceptionType.ALREADY_IN_PROGRESS;
-import static com.now.naaga.game.exception.GameExceptionType.NOT_EXIST;
+import static com.now.naaga.game.exception.GameExceptionType.*;
 
 @Transactional
 @Service
@@ -89,7 +88,7 @@ public class GameService {
         List<GameResult> gameResultsByGameId = gameResultRepository.findByGameId(gameId);
 
         if (gameResultsByGameId.isEmpty()) {
-            throw new IllegalArgumentException("해당게임의 게임결과가 존재하지 않습니다.");
+            throw new GameException(GAME_RESULT_NOT_EXIST);
         }
 
         return gameResultsByGameId.get(0);

--- a/backend/src/main/java/com/now/naaga/game/application/GameService.java
+++ b/backend/src/main/java/com/now/naaga/game/application/GameService.java
@@ -79,13 +79,13 @@ public class GameService {
 
     @Transactional(readOnly = true)
     public List<Game> findGamesByStatus(final FindGameByStatusCommand findGameByStatusCommand) {
-        Player player = playerService.findPlayerById(findGameByStatusCommand.playerId());
+        final Player player = playerService.findPlayerById(findGameByStatusCommand.playerId());
         return gameRepository.findByPlayerIdAndGameStatus(player.getId(), findGameByStatusCommand.gameStatus());
     }
 
     @Transactional(readOnly = true)
     public GameResult findGameResultByGameId(final Long gameId) {
-        List<GameResult> gameResultsByGameId = gameResultRepository.findByGameId(gameId);
+        final List<GameResult> gameResultsByGameId = gameResultRepository.findByGameId(gameId);
 
         if (gameResultsByGameId.isEmpty()) {
             throw new GameException(GAME_RESULT_NOT_EXIST);

--- a/backend/src/main/java/com/now/naaga/game/application/GameService.java
+++ b/backend/src/main/java/com/now/naaga/game/application/GameService.java
@@ -16,6 +16,7 @@ import com.now.naaga.place.domain.Place;
 import com.now.naaga.place.domain.Position;
 import com.now.naaga.player.application.PlayerService;
 import com.now.naaga.player.domain.Player;
+import com.now.naaga.player.presentation.dto.PlayerRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -101,9 +102,13 @@ public class GameService {
     }
 
     @Transactional(readOnly = true)
-    public List<GameRecord> findAllGameResult() {
-        final List<GameResult> gameResults = gameResultRepository.findAll();
-        gameResults.sort((gr1, gr2) -> gr2.getCreatedAt().compareTo(gr1.getCreatedAt()));
+    public List<GameRecord> findAllGameResult(final PlayerRequest playerRequest) {
+        List<Game> gamesByPlayerId = gameRepository.findByPlayerId(playerRequest.playerId());
+        List<GameResult> gameResults = gamesByPlayerId.stream()
+                .map(game -> findGameResultByGameId(game.getId()))
+                .sorted((gr1, gr2) -> gr2.getCreatedAt().compareTo(gr1.getCreatedAt()))
+                .collect(Collectors.toList());
+
         return gameResults.stream()
                 .map(GameRecord::from)
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/now/naaga/game/domain/Game.java
+++ b/backend/src/main/java/com/now/naaga/game/domain/Game.java
@@ -118,7 +118,7 @@ public class Game extends BaseEntity {
         return FAIL;
     }
 
-    private ResultType endGameByArrival(Position position) {
+    private ResultType endGameByArrival(final Position position) {
         remainingAttempts--;
         if (isPlayerArrived(position)) {
             return endGameWithSuccess();
@@ -126,9 +126,7 @@ public class Game extends BaseEntity {
         return endGameWithFailure();
     }
 
-    // todo : place의 변수명을 isCoordinateInsideBounds 또는 isPositionInsideBounds 또는 isPositionWithinRange로 바꾸고 싶다
-    //또, 이 메서드에 범위를 함께 넘겨주는 것이 마땅해보인다.
-    private boolean isPlayerArrived(Position position) {
+    private boolean isPlayerArrived(final Position position) {
         return place.isInValidRange(position);
     }
 

--- a/backend/src/main/java/com/now/naaga/game/domain/Game.java
+++ b/backend/src/main/java/com/now/naaga/game/domain/Game.java
@@ -12,13 +12,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static com.now.naaga.game.domain.GameStatus.DONE;
+import static com.now.naaga.game.domain.ResultType.FAIL;
+import static com.now.naaga.game.domain.ResultType.SUCCESS;
 import static com.now.naaga.game.exception.GameExceptionType.INACCESSIBLE_AUTHENTICATION;
 import static com.now.naaga.game.exception.GameExceptionType.NOT_ARRIVED;
 
 @Entity
 public class Game extends BaseEntity {
 
-    public static final double MIN_RANGE = 0.05;
+    public static final int MAX_ATTEMPT_COUNT = 5;
+    public static final double MIN_RANGE = 0.02;
 
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Id
@@ -48,12 +52,13 @@ public class Game extends BaseEntity {
     private List<Hint> hints;
 
     private LocalDateTime startTime;
+    private LocalDateTime endTime;
 
     protected Game() {
     }
 
     public Game(final Player player, final Place place, final Position startPosition) {
-        this(null, GameStatus.IN_PROGRESS, player, place, startPosition, 5, new ArrayList<>(), LocalDateTime.now());
+        this(GameStatus.IN_PROGRESS, player, place, startPosition, MAX_ATTEMPT_COUNT, new ArrayList<>(), LocalDateTime.now(), null);
     }
 
     public Game(final GameStatus gameStatus,
@@ -62,8 +67,9 @@ public class Game extends BaseEntity {
                 final Position startPosition,
                 final int remainingAttempts,
                 final List<Hint> hints,
-                final LocalDateTime startTime) {
-        this(null, gameStatus, player, place, startPosition, remainingAttempts, hints, startTime);
+                final LocalDateTime startTime,
+                final LocalDateTime endTime) {
+        this(null, gameStatus, player, place, startPosition, remainingAttempts, hints, startTime, endTime);
     }
 
     public Game(final Long id,
@@ -73,7 +79,8 @@ public class Game extends BaseEntity {
                 final Position startPosition,
                 final int remainingAttempts,
                 final List<Hint> hints,
-                final LocalDateTime startTime) {
+                final LocalDateTime startTime,
+                final LocalDateTime endTime) {
         this.id = id;
         this.gameStatus = gameStatus;
         this.player = player;
@@ -82,6 +89,7 @@ public class Game extends BaseEntity {
         this.remainingAttempts = remainingAttempts;
         this.hints = hints;
         this.startTime = startTime;
+        this.endTime = endTime;
     }
 
     public void validateOwner(final Player player) {
@@ -98,6 +106,45 @@ public class Game extends BaseEntity {
 
     public void changeGameStatus(final GameStatus gameStatus) {
         this.gameStatus = gameStatus;
+    }
+
+    private boolean isGameEnded() {
+        return gameStatus == DONE;
+    }
+
+    private ResultType giveUpGame() {
+        gameStatus = DONE;
+        endTime = LocalDateTime.now();
+        return FAIL;
+    }
+
+    private ResultType endGameByArrival(Position position) {
+        remainingAttempts--;
+        if (isPlayerArrived(position)) {
+            return endGameWithSuccess();
+        }
+        return endGameWithFailure();
+    }
+
+    // todo : place의 변수명을 isCoordinateInsideBounds 또는 isPositionInsideBounds 또는 isPositionWithinRange로 바꾸고 싶다
+    //또, 이 메서드에 범위를 함께 넘겨주는 것이 마땅해보인다.
+    private boolean isPlayerArrived(Position position) {
+        return place.isInValidRange(position);
+    }
+
+    private ResultType endGameWithSuccess() {
+        gameStatus = DONE;
+        endTime = LocalDateTime.now();
+        return SUCCESS;
+    }
+
+    private ResultType endGameWithFailure() {
+        if (remainingAttempts == 0) {
+            gameStatus = DONE;
+            endTime = LocalDateTime.now();
+            return FAIL;
+        }
+        throw new GameException(NOT_ARRIVED);
     }
 
     public Long getId() {
@@ -130,6 +177,10 @@ public class Game extends BaseEntity {
 
     public LocalDateTime getStartTime() {
         return startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
     }
 
     @Override

--- a/backend/src/main/java/com/now/naaga/game/domain/GameRecord.java
+++ b/backend/src/main/java/com/now/naaga/game/domain/GameRecord.java
@@ -43,12 +43,14 @@ public class GameRecord {
         return new GameRecord(gameResult, totalPlayTime, distance, hintUses, tryCount, startTime, finishTime);
     }
 
-    private static LocalDateTime calculateTotalPlayTime(LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        Duration duration = Duration.between(startDateTime, endDateTime);
+    private static LocalDateTime calculateTotalPlayTime(final LocalDateTime startDateTime,
+                                                        final LocalDateTime endDateTime) {
+        final Duration duration = Duration.between(startDateTime, endDateTime);
         return startDateTime.plus(duration);
     }
 
-    private static int calculateDistance(Position startPosition, Position destinationPosition) {
+    private static int calculateDistance(final Position startPosition,
+                                         final Position destinationPosition) {
         return (int) startPosition.calculateDistance(destinationPosition);
     }
 

--- a/backend/src/main/java/com/now/naaga/game/domain/GameRecord.java
+++ b/backend/src/main/java/com/now/naaga/game/domain/GameRecord.java
@@ -1,0 +1,82 @@
+package com.now.naaga.game.domain;
+
+import com.now.naaga.place.domain.Position;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static com.now.naaga.game.domain.Game.MAX_ATTEMPT_COUNT;
+
+public class GameRecord {
+
+    private GameResult gameResult;
+    private LocalDateTime totalPlayTime;
+    private int distance;
+    private int hintUses;
+    private int tryCount;
+    private LocalDateTime startTime;
+    private LocalDateTime finishTime;
+
+    public GameRecord(final GameResult gameResult,
+                      final LocalDateTime totalPlayTime,
+                      final int distance,
+                      final int hintUses,
+                      final int tryCount,
+                      final LocalDateTime startTime,
+                      final LocalDateTime finishTime) {
+        this.gameResult = gameResult;
+        this.totalPlayTime = totalPlayTime;
+        this.distance = distance;
+        this.hintUses = hintUses;
+        this.tryCount = tryCount;
+        this.startTime = startTime;
+        this.finishTime = finishTime;
+    }
+
+    public static GameRecord from(final GameResult gameResult) {
+        final LocalDateTime totalPlayTime = calculateTotalPlayTime(gameResult.getGame().getStartTime(), gameResult.getGame().getEndTime());
+        final int distance = calculateDistance(gameResult.getGame().getStartPosition(), gameResult.getGame().getPlace().getPosition());
+        final int hintUses = gameResult.getGame().getHints().size();
+        final int tryCount = MAX_ATTEMPT_COUNT - gameResult.getGame().getRemainingAttempts();
+        final LocalDateTime startTime = gameResult.getGame().getStartTime();
+        final LocalDateTime finishTime = gameResult.getGame().getEndTime();
+        return new GameRecord(gameResult, totalPlayTime, distance, hintUses, tryCount, startTime, finishTime);
+    }
+
+    private static LocalDateTime calculateTotalPlayTime(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        Duration duration = Duration.between(startDateTime, endDateTime);
+        return startDateTime.plus(duration);
+    }
+
+    private static int calculateDistance(Position startPosition, Position destinationPosition) {
+        return (int) startPosition.calculateDistance(destinationPosition);
+    }
+
+    public GameResult getGameResult() {
+        return gameResult;
+    }
+
+    public LocalDateTime getTotalPlayTime() {
+        return totalPlayTime;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+
+    public int getHintUses() {
+        return hintUses;
+    }
+
+    public int getTryCount() {
+        return tryCount;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public LocalDateTime getFinishTime() {
+        return finishTime;
+    }
+}

--- a/backend/src/main/java/com/now/naaga/game/domain/GameResult.java
+++ b/backend/src/main/java/com/now/naaga/game/domain/GameResult.java
@@ -2,16 +2,8 @@ package com.now.naaga.game.domain;
 
 import com.now.naaga.common.domain.BaseEntity;
 import com.now.naaga.score.domain.Score;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
+
 import java.util.Objects;
 
 @Entity
@@ -24,8 +16,6 @@ public class GameResult extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ResultType resultType;
 
-    private LocalDateTime arrivedTime;
-
     @Embedded
     private Score score;
 
@@ -37,20 +27,17 @@ public class GameResult extends BaseEntity {
     }
 
     public GameResult(final ResultType resultType,
-                      final LocalDateTime arrivedTime,
                       final Score score,
                       final Game game) {
-        this(null, resultType, arrivedTime, score, game);
+        this(null, resultType, score, game);
     }
 
     public GameResult(final Long id,
                       final ResultType resultType,
-                      final LocalDateTime arrivedTime,
                       final Score score,
                       final Game game) {
         this.id = id;
         this.resultType = resultType;
-        this.arrivedTime = arrivedTime;
         this.score = score;
         this.game = game;
     }
@@ -61,10 +48,6 @@ public class GameResult extends BaseEntity {
 
     public ResultType getResultType() {
         return resultType;
-    }
-
-    public LocalDateTime getArrivedTime() {
-        return arrivedTime;
     }
 
     public Score getScore() {
@@ -97,7 +80,6 @@ public class GameResult extends BaseEntity {
         return "GameResult{" +
                 "id=" + id +
                 ", resultType=" + resultType +
-                ", arrivedTime=" + arrivedTime +
                 ", score=" + score +
                 ", gameId=" + game.getId() +
                 '}';

--- a/backend/src/main/java/com/now/naaga/game/exception/GameExceptionType.java
+++ b/backend/src/main/java/com/now/naaga/game/exception/GameExceptionType.java
@@ -28,6 +28,18 @@ public enum GameExceptionType implements BaseExceptionType {
             HttpStatus.BAD_REQUEST,
             "목적지에 도착하지 않았습니다."
     ),
+
+    INVALID_QUERY_PARAMETERS(
+            404,
+            HttpStatus.BAD_REQUEST,
+            "쿼리파라미터가 잘못 요청되었습니다."
+    ),
+
+    GAME_RESULT_NOT_EXIST(
+            405,
+            HttpStatus.NOT_FOUND,
+            "해당게임의 게임결과가 존재하지 않습니다."
+    )
     ;
 
     private final int errorCode;

--- a/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
@@ -8,6 +8,7 @@ import com.now.naaga.game.application.dto.FindGameByStatusCommand;
 import com.now.naaga.game.application.dto.FinishGameCommand;
 import com.now.naaga.game.domain.Game;
 import com.now.naaga.game.domain.GameRecord;
+import com.now.naaga.game.exception.GameException;
 import com.now.naaga.game.presentation.dto.*;
 import com.now.naaga.player.presentation.dto.PlayerRequest;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.now.naaga.game.exception.GameExceptionType.INVALID_QUERY_PARAMETERS;
 
 @RequestMapping("/games")
 @RestController
@@ -86,7 +89,7 @@ public class GameController {
                                                                       @RequestParam final String sortBy,
                                                                       @RequestParam final String order) {
         if (!sortBy.equals("time") && order.equals("descending")) {
-            throw new IllegalArgumentException("잘못된 요청입니다.");
+            throw new GameException(INVALID_QUERY_PARAMETERS);
         }
 
         final List<GameRecord> gameRecords = gameService.findAllGameResult();

--- a/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
@@ -90,8 +90,8 @@ public class GameController {
             throw new IllegalArgumentException("잘못된 요청입니다.");
         }
 
-        List<GameRecord> gameRecords = gameService.findAllGameResult();
-        List<GameResultResponse> gameResultResponseList = gameRecords.stream()
+        final List<GameRecord> gameRecords = gameService.findAllGameResult();
+        final List<GameResultResponse> gameResultResponseList = gameRecords.stream()
                 .map(GameResultResponse::from)
                 .collect(Collectors.toList());
 

--- a/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
@@ -44,7 +44,6 @@ public class GameController {
     public ResponseEntity<GameStatusResponse> changeGameStatus(@Auth final PlayerRequest playerRequest,
                                                                @RequestBody final FinishGameRequest finishGameRequest,
                                                                @PathVariable final Long gameId) {
-        // TODO: 8/1/23 FinishGameCommand에 EndType 추가해야함
         final FinishGameCommand finishGameCommand = FinishGameCommand.of(playerRequest, finishGameRequest, gameId);
         final Game game = gameService.finishGame(finishGameCommand);
         return ResponseEntity

--- a/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
@@ -92,7 +92,7 @@ public class GameController {
             throw new GameException(INVALID_QUERY_PARAMETERS);
         }
 
-        final List<GameRecord> gameRecords = gameService.findAllGameResult();
+        final List<GameRecord> gameRecords = gameService.findAllGameResult(playerRequest);
         final List<GameResultResponse> gameResultResponseList = gameRecords.stream()
                 .map(GameResultResponse::from)
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
@@ -1,16 +1,14 @@
 package com.now.naaga.game.presentation;
 
 import com.now.naaga.auth.annotation.Auth;
-import com.now.naaga.game.application.dto.FindGameByIdCommand;
 import com.now.naaga.game.application.GameService;
 import com.now.naaga.game.application.dto.CreateGameCommand;
+import com.now.naaga.game.application.dto.FindGameByIdCommand;
 import com.now.naaga.game.application.dto.FindGameByStatusCommand;
 import com.now.naaga.game.application.dto.FinishGameCommand;
 import com.now.naaga.game.domain.Game;
-import com.now.naaga.game.presentation.dto.CreateGameRequest;
-import com.now.naaga.game.presentation.dto.FinishGameRequest;
-import com.now.naaga.game.presentation.dto.GameResponse;
-import com.now.naaga.game.presentation.dto.GameStatusResponse;
+import com.now.naaga.game.domain.GameRecord;
+import com.now.naaga.game.presentation.dto.*;
 import com.now.naaga.player.presentation.dto.PlayerRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequestMapping("/games")
 @RestController
@@ -72,5 +71,32 @@ public class GameController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(gameResponses);
+    }
+
+    @GetMapping("/{gameId}/result")
+    public ResponseEntity<GameResultResponse> findGameResult(@Auth final PlayerRequest playerRequest,
+                                                             @PathVariable final Long gameId) {
+        final GameRecord gameRecord = gameService.findGameResult(gameId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(GameResultResponse.from(gameRecord));
+    }
+
+    @GetMapping("/results")
+    public ResponseEntity<List<GameResultResponse>> findAllGameResult(@Auth final PlayerRequest playerRequest,
+                                                                      @RequestParam final String sortBy,
+                                                                      @RequestParam final String order) {
+        if (!sortBy.equals("time") && order.equals("descending")) {
+            throw new IllegalArgumentException("잘못된 요청입니다.");
+        }
+
+        List<GameRecord> gameRecords = gameService.findAllGameResult();
+        List<GameResultResponse> gameResultResponseList = gameRecords.stream()
+                .map(GameResultResponse::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(gameResultResponseList);
     }
 }

--- a/backend/src/main/java/com/now/naaga/game/presentation/dto/CoordinateResponse.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/dto/CoordinateResponse.java
@@ -1,0 +1,11 @@
+package com.now.naaga.game.presentation.dto;
+
+import com.now.naaga.place.domain.Position;
+
+//TODO:CoordinateResponse와 CoordinateRequest의 인자가 같은데 CoordinateDto통일은 어떤지..
+public record CoordinateResponse(Double latitude,
+                                 Double longitude) {
+    public static CoordinateResponse of(final Position position) {
+        return new CoordinateResponse( position.getLatitude().doubleValue(), position.getLongitude().doubleValue());
+    }
+}

--- a/backend/src/main/java/com/now/naaga/game/presentation/dto/GameDestinationResponse.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/dto/GameDestinationResponse.java
@@ -1,0 +1,14 @@
+package com.now.naaga.game.presentation.dto;
+
+import com.now.naaga.place.domain.Place;
+
+public record GameDestinationResponse(Long id,
+                                      String name,
+                                      CoordinateResponse coordinate,
+                                      String imageUrl,
+                                      String description) {
+
+    public static GameDestinationResponse from(final Place place) {
+        return new GameDestinationResponse(place.getId(), place.getName(), CoordinateResponse.of(place.getPosition()), place.getImageUrl(), place.getDescription());
+    }
+}

--- a/backend/src/main/java/com/now/naaga/game/presentation/dto/GameResultResponse.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/dto/GameResultResponse.java
@@ -1,0 +1,34 @@
+package com.now.naaga.game.presentation.dto;
+
+import com.now.naaga.game.domain.GameRecord;
+import com.now.naaga.game.domain.ResultType;
+
+import java.time.LocalDateTime;
+
+public record GameResultResponse(Long id,
+                                 Long GameId,
+                                 GameDestinationResponse destination,
+                                 ResultType resultType,
+                                 int score,
+                                 LocalDateTime totalPlayTime,
+                                 int distance,
+                                 int hintUses,
+                                 int tryCount,
+                                 LocalDateTime startTime,
+                                 LocalDateTime finishTime) {
+
+    public static GameResultResponse from(final GameRecord gameRecord) {
+        return new GameResultResponse(
+                gameRecord.getGameResult().getId(),
+                gameRecord.getGameResult().getGame().getId(),
+                GameDestinationResponse.from(gameRecord.getGameResult().getGame().getPlace()),
+                gameRecord.getGameResult().getResultType(),
+                gameRecord.getGameResult().getScore().getValue(),
+                gameRecord.getTotalPlayTime(),
+                gameRecord.getDistance(),
+                gameRecord.getHintUses(),
+                gameRecord.getTryCount(),
+                gameRecord.getStartTime(),
+                gameRecord.getFinishTime());
+    }
+}

--- a/backend/src/main/java/com/now/naaga/game/repository/GameRepository.java
+++ b/backend/src/main/java/com/now/naaga/game/repository/GameRepository.java
@@ -9,4 +9,6 @@ public interface GameRepository extends JpaRepository<Game, Long> {
 
     List<Game> findByPlayerIdAndGameStatus(final Long playerId,
                                            final GameStatus gameStatus);
+
+    List<Game> findByPlayerId(Long playerId);
 }

--- a/backend/src/main/java/com/now/naaga/game/repository/GameResultRepository.java
+++ b/backend/src/main/java/com/now/naaga/game/repository/GameResultRepository.java
@@ -3,6 +3,9 @@ package com.now.naaga.game.repository;
 import com.now.naaga.game.domain.GameResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface GameResultRepository extends JpaRepository<GameResult, Long> {
 
+    List<GameResult> findByGameId(final Long gameId);
 }

--- a/backend/src/test/java/com/now/naaga/acceptance/game/GameControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/acceptance/game/GameControllerTest.java
@@ -1,0 +1,165 @@
+package com.now.naaga.acceptance.game;
+
+import com.now.naaga.acceptance.ControllerTest;
+import com.now.naaga.game.domain.*;
+import com.now.naaga.game.presentation.dto.GameResultResponse;
+import com.now.naaga.game.repository.GameRepository;
+import com.now.naaga.game.repository.GameResultRepository;
+import com.now.naaga.member.domain.Member;
+import com.now.naaga.member.persistence.repository.MemberRepository;
+import com.now.naaga.place.domain.Place;
+import com.now.naaga.place.domain.Position;
+import com.now.naaga.place.persistence.repository.PlaceRepository;
+import com.now.naaga.player.domain.Player;
+import com.now.naaga.player.persistence.repository.PlayerRepository;
+import com.now.naaga.score.domain.Score;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GameControllerTest extends ControllerTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    PlayerRepository playerRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PlaceRepository placeRepository;
+
+    @Autowired
+    GameRepository gameRepository;
+
+    @Autowired
+    GameResultRepository gameResultRepository;
+
+    private Long gameId_1;
+    private Long gameId_2;
+    private Long gameResultId_1;
+    private Long gameResultId_2;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+
+        final Member saveMember1 = memberRepository.save(new Member("chaechae@woo.com", "1234"));
+        final Member saveMember2 = memberRepository.save(new Member("irea@woo.com", "1234"));
+        final Member saveMember3 = memberRepository.save(new Member("cherry@woo.com", "1234"));
+
+        final Player player1 = playerRepository.save(new Player("채채", new Score(15), saveMember1));
+        final Player player2 = playerRepository.save(new Player("이레", new Score(17), saveMember2));
+        final Player player3 = playerRepository.save(new Player("채리", new Score(20), saveMember3));
+
+        final Place place1 = new Place("어딘가", "멋진곳", new Position(BigDecimal.valueOf(37.514258), BigDecimal.valueOf(127.100883)), "imageUrl", player1);
+        final Place place2 = new Place("어딘가에", "더멋진곳", new Position(BigDecimal.valueOf(37.514258), BigDecimal.valueOf(127.100883)), "imageUrl", player1);
+        final Place savePlace1 = placeRepository.save(place1);
+        final Place savePlace2 = placeRepository.save(place2);
+        List<Hint> hints = new ArrayList<>();
+        final LocalDateTime startTime1 = LocalDateTime.of(2023, 8, 2, 13, 30);
+        final LocalDateTime endTime1 = LocalDateTime.of(2023, 8, 2, 15, 30);
+
+        final LocalDateTime startTime2 = LocalDateTime.of(2024, 8, 2, 13, 30);
+        final LocalDateTime endTime2 = LocalDateTime.of(2024, 8, 2, 15, 30);
+
+        final Game game1 = new Game(GameStatus.DONE, player3, savePlace1,
+                new Position(BigDecimal.valueOf(37.512256),
+                        BigDecimal.valueOf(127.112584)), 2, hints, startTime1, endTime1);
+        final Game game2 = new Game(GameStatus.DONE, player2, savePlace2,
+                new Position(BigDecimal.valueOf(37.512256),
+                        BigDecimal.valueOf(127.112584)), 3, hints, startTime2, endTime2);
+        final Game saveGame1 = gameRepository.save(game1);
+        final Game saveGame2 = gameRepository.save(game2);
+        final GameResult gameResult1 = new GameResult(ResultType.SUCCESS, new Score(15), saveGame1);
+        final GameResult gameResult2 = new GameResult(ResultType.FAIL, new Score(10), saveGame2);
+        final GameResult saveGameResult1 = gameResultRepository.save(gameResult1);
+        final GameResult saveGameResult2 = gameResultRepository.save(gameResult2);
+
+        gameId_1 = saveGame1.getId();
+        gameResultId_1 = saveGameResult1.getId();
+        gameId_2 = saveGame2.getId();
+        gameResultId_2 = saveGameResult2.getId();
+    }
+
+    @Test
+    public void 게임_아이디로_게임결과를_조회한다() {
+        // given
+        final String encodedCredentials = calculateEncodedCredentials();
+        final Long gameId1 = gameId_1;
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Basic " + encodedCredentials)
+                .when().get("/games/" + gameId1 + "/result")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+
+        // then
+        final GameResultResponse gameResultResponse = response.as(GameResultResponse.class);
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            softly.assertThat(gameResultResponse.id()).isEqualTo(gameResultId_1);
+            softly.assertThat(gameResultResponse.GameId()).isEqualTo(gameId1);
+            softly.assertThat(gameResultResponse.destination().name()).isEqualTo("어딘가");
+            softly.assertThat(gameResultResponse.resultType()).isEqualTo(ResultType.SUCCESS);
+        });
+    }
+
+    @Test
+    public void 모든_게임_결과를_도착시간_기준으로_내림차순하여_조회한다() {
+        // given
+        final String encodedCredentials = calculateEncodedCredentials();
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Basic " + encodedCredentials)
+                .param("sortBy", "time")
+                .param("order", "descending")
+                .when().get("/games/results")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .extract();
+
+        // then
+        final List<GameResultResponse> gameResultResponses = response.jsonPath().getList(".", GameResultResponse.class);
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+            softly.assertThat(gameResultResponses).hasSize(2);
+            softly.assertThat(gameResultResponses.get(0).GameId()).isEqualTo(2L);
+            softly.assertThat(gameResultResponses.get(1).GameId()).isEqualTo(1L);
+        });
+
+    }
+
+    private String calculateEncodedCredentials() {
+        final String username = "chaechae@woo.com";
+        final String password = "1234";
+        final String credentials = username + ":" + password;
+        return Base64.getEncoder().encodeToString(credentials.getBytes());
+    }
+}

--- a/backend/src/test/java/com/now/naaga/acceptance/game/GameControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/acceptance/game/GameControllerTest.java
@@ -82,10 +82,10 @@ class GameControllerTest extends ControllerTest {
         final LocalDateTime startTime2 = LocalDateTime.of(2024, 8, 2, 13, 30);
         final LocalDateTime endTime2 = LocalDateTime.of(2024, 8, 2, 15, 30);
 
-        final Game game1 = new Game(GameStatus.DONE, player3, savePlace1,
+        final Game game1 = new Game(GameStatus.DONE, player1, savePlace1,
                 new Position(BigDecimal.valueOf(37.512256),
                         BigDecimal.valueOf(127.112584)), 2, hints, startTime1, endTime1);
-        final Game game2 = new Game(GameStatus.DONE, player2, savePlace2,
+        final Game game2 = new Game(GameStatus.DONE, player1, savePlace2,
                 new Position(BigDecimal.valueOf(37.512256),
                         BigDecimal.valueOf(127.112584)), 3, hints, startTime2, endTime2);
         final Game saveGame1 = gameRepository.save(game1);


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #145 

## 🛠️ 작업 내용
- [x] 게임 아이디를 통해 게임결과를 단건 조회한다.
- [x] 플레이어아이디를 통해 게임 결과를 전체 조회한다.
    - [x] 도착시간을 기준으로 내림차순하여 정렬한다. 

## 🎯 리뷰 포인트

## ⏳ 작업 시간
추정 시간:   3시간
실제 시간:   3시간

