### PR TITLE
[AN] feat: API 수정으로 인한 변경사항 적용

### DIFF
--- a/android/app/src/main/java/com/now/naaga/data/mapper/AdventureResultMapper.kt
+++ b/android/app/src/main/java/com/now/naaga/data/mapper/AdventureResultMapper.kt
@@ -4,7 +4,6 @@ import com.now.domain.model.AdventureResult
 import com.now.domain.model.AdventureResultType
 import com.now.naaga.data.remote.dto.AdventureResultDto
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 fun AdventureResultDto.toDomain(): AdventureResult {
     return AdventureResult(
@@ -13,7 +12,7 @@ fun AdventureResultDto.toDomain(): AdventureResult {
         destination = destination.toDomain(),
         resultType = AdventureResultType.findByName(resultType),
         score = score,
-        playTime = LocalTime.parse(totalPlayTime),
+        playTime = totalPlayTime,
         distance = distance,
         hintUses = hintUses,
         tryCount = tryCount,

--- a/android/app/src/main/java/com/now/naaga/data/mapper/StatisticsMapper.kt
+++ b/android/app/src/main/java/com/now/naaga/data/mapper/StatisticsMapper.kt
@@ -2,7 +2,6 @@ package com.now.naaga.data.mapper
 
 import com.now.domain.model.Statistics
 import com.now.naaga.data.remote.dto.StatisticsDto
-import java.time.LocalTime
 
 fun StatisticsDto.toDomain(): Statistics {
     return Statistics(
@@ -10,7 +9,7 @@ fun StatisticsDto.toDomain(): Statistics {
         successCount = successGameCount,
         failureCount = failGameCount,
         totalDistance = totalDistance,
-        totalPlayTime = LocalTime.parse(totalPlayTime),
+        totalPlayTime = totalPlayTime,
         totalHintUses = totalUsedHintCount,
     )
 }

--- a/android/app/src/main/java/com/now/naaga/data/remote/dto/AdventureResultDto.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/dto/AdventureResultDto.kt
@@ -9,7 +9,7 @@ data class AdventureResultDto(
     val destination: PlaceDto,
     val resultType: String,
     val score: Int,
-    val totalPlayTime: String,
+    val totalPlayTime: Int,
     val distance: Int,
     val hintUses: Int,
     val tryCount: Int,

--- a/android/app/src/main/java/com/now/naaga/data/remote/dto/StatisticsDto.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/dto/StatisticsDto.kt
@@ -8,6 +8,6 @@ data class StatisticsDto(
     val successGameCount: Int,
     val failGameCount: Int,
     val totalDistance: Int,
-    val totalPlayTime: String,
+    val totalPlayTime: Int,
     val totalUsedHintCount: Int,
 )

--- a/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultActivity.kt
@@ -15,8 +15,6 @@ import com.now.naaga.data.repository.DefaultAdventureRepository
 import com.now.naaga.data.repository.DefaultRankRepository
 import com.now.naaga.databinding.ActivityAdventureResultBinding
 import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
-import java.time.LocalTime
-import java.time.format.DateTimeFormatter
 
 class AdventureResultActivity : AppCompatActivity() {
     private lateinit var binding: ActivityAdventureResultBinding
@@ -50,7 +48,6 @@ class AdventureResultActivity : AppCompatActivity() {
         viewModel.adventureResult.observe(this) { adventureResult ->
             setResultType(adventureResult)
             setPhoto(adventureResult.destination.image)
-            setPlayTime(adventureResult.playTime)
         }
 
         viewModel.errorMessage.observe(this) { errorMessage ->
@@ -88,11 +85,6 @@ class AdventureResultActivity : AppCompatActivity() {
             .into(binding.ivAdventureResultPhoto)
     }
 
-    private fun setPlayTime(playTime: LocalTime) {
-        val timeFormatter = DateTimeFormatter.ofPattern(TIME_FORMATTER_PATTERN)
-        binding.tvAdventureResultPlayTime.text = playTime.format(timeFormatter)
-    }
-
     private fun setClickListeners() {
         binding.btnAdventureResultReturn.setOnClickListener {
             startActivity(BeginAdventureActivity.getIntent(this))
@@ -102,7 +94,6 @@ class AdventureResultActivity : AppCompatActivity() {
     companion object {
         private const val GAME_ID = "GAME_ID"
         private const val MESSAGE_IN_RESULT_TYPE_NONE = "네트워크에 문제가 생겼습니다."
-        private const val TIME_FORMATTER_PATTERN = "HH:mm:ss"
 
         fun getIntentWithGameId(context: Context, gameId: Long): Intent {
             return Intent(context, AdventureResultActivity::class.java).apply {

--- a/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultActivity.kt
@@ -25,14 +25,19 @@ class AdventureResultActivity : AppCompatActivity() {
         binding = ActivityAdventureResultBinding.inflate(layoutInflater)
         setContentView(binding.root)
         initViewModel()
-        viewModel.fetchGameResult(getIntentData())
+        viewModel.fetchGameResult(getIntentData() ?: return finish())
         viewModel.fetchMyRank()
         subscribeObserving()
         setClickListeners()
     }
 
-    private fun getIntentData(): Long {
-        return intent.getLongExtra(GAME_ID, -1)
+    private fun getIntentData(): Long? {
+        val id = intent.getLongExtra(GAME_ID, -1)
+        return if (id == -1L) {
+            null
+        } else {
+            id
+        }
     }
 
     private fun initViewModel() {

--- a/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultViewModel.kt
@@ -22,9 +22,9 @@ class AdventureResultViewModel(
     private val _errorMessage = MutableLiveData<String>()
     val errorMessage: LiveData<String> = _errorMessage
 
-    fun fetchGameResult(gameId: Long) {
+    fun fetchGameResult(adventureId: Long) {
         adventureRepository.fetchAdventureResult(
-            TEMP_MOCK_GAME_ID,
+            adventureId,
             callback = { result ->
                 result
                     .onSuccess { _adventureResult.value = it }
@@ -48,9 +48,5 @@ class AdventureResultViewModel(
             is NaagaThrowable.ServerConnectFailure ->
                 _errorMessage.value = throwable.userMessage
         }
-    }
-
-    companion object {
-        private const val TEMP_MOCK_GAME_ID = 1L
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/mypage/MyPageMapper.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/mypage/MyPageMapper.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.now.domain.model.Place
 import com.now.domain.model.Statistics
 import com.now.naaga.R
-import java.time.LocalTime
 
 fun Statistics.toUiModel(context: Context): List<MyPageStatisticsUiModel> {
     return listOf(
@@ -24,7 +23,7 @@ fun Statistics.toUiModel(context: Context): List<MyPageStatisticsUiModel> {
             context.getString(R.string.mypage_adventure_failure),
         ),
         MyPageStatisticsUiModel(
-            totalPlayTime.getTotalMinute(),
+            totalPlayTime,
             context.getString(R.string.mypage_minute),
             context.getString(R.string.mypage_total_play_time),
         ),
@@ -39,10 +38,6 @@ fun Statistics.toUiModel(context: Context): List<MyPageStatisticsUiModel> {
             context.getString(R.string.mypage_total_hint_uses),
         ),
     )
-}
-
-private fun LocalTime.getTotalMinute(): Int {
-    return hour * 60 + minute
 }
 
 fun Place.toUiModel(): MyPagePlaceUiModel {

--- a/android/app/src/main/res/layout/activity_adventure_result.xml
+++ b/android/app/src/main/res/layout/activity_adventure_result.xml
@@ -56,25 +56,23 @@
             android:id="@+id/iv_adventureResult_stamp"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@id/iv_adventureResult_photo"
+            app:layout_constraintBottom_toBottomOf="@id/iv_adventureResult_photo"
             tools:src="@drawable/ic_success" />
 
         <LinearLayout
             android:id="@+id/ll_adventureResult_window"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="32dp"
-            android:layout_marginEnd="32dp"
-            android:layout_marginBottom="148dp"
+            android:layout_marginHorizontal="32dp"
+            android:layout_marginTop="8dp"
             android:background="@drawable/rect_radius_small"
             android:backgroundTint="@color/white"
             android:orientation="vertical"
             android:paddingHorizontal="24dp"
             android:paddingVertical="20dp"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_adventureResult_destination">
@@ -93,35 +91,29 @@
                     android:text="@string/adventureResult_time_description"
                     android:textColor="@color/black"
                     android:textSize="20sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
-                <androidx.constraintlayout.widget.ConstraintLayout
+                <TextView
+                    android:id="@+id/tv_adventureResult_playTime"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="40dp"
+                    android:text="@{@string/adventureResult_play_time_value(viewModel.adventureResult.playTime)}"
+                    android:fontFamily="@font/pretendard_bold"
+                    android:textColor="@color/white"
+                    android:textSize="20sp"
+                    android:gravity="end"
                     android:background="@drawable/rect_radius_small"
                     android:backgroundTint="@color/main_navy"
+                    android:layout_marginStart="40dp"
                     android:paddingVertical="4dp"
                     android:paddingEnd="@dimen/space_default_medium"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@id/tv_adventureResult_timeTitle"
-                    app:layout_constraintTop_toTopOf="parent">
-
-                    <TextView
-                        android:id="@+id/tv_adventureResult_playTime"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:fontFamily="@font/pretendard_bold"
-                        android:textColor="@color/white"
-                        android:textSize="16sp"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        tools:text="00:30:32" />
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="30분" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -152,13 +144,13 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendard_bold"
-                    android:text="@{@string/adventureResult_value(viewModel.adventureResult.distance)}"
+                    android:text="@{@string/adventureResult_distance_value(viewModel.adventureResult.distance)}"
                     android:textColor="@color/black"
                     android:textSize="24sp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    tools:text="+13" />
+                    tools:text="+200m" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -190,13 +182,13 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendard_bold"
-                    android:text="@{`` + viewModel.adventureResult.hintUses}"
+                    android:text="@{@string/adventureResult_hint_value(viewModel.adventureResult.hintUses)}"
                     android:textColor="@color/black"
                     android:textSize="24sp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    tools:text="13" />
+                    tools:text="2개" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -227,13 +219,13 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:fontFamily="@font/pretendard_bold"
-                    android:text="@{``+ viewModel.adventureResult.tryCount}"
+                    android:text="@{@string/adventureResult_try_count_value(viewModel.adventureResult.tryCount)}"
                     android:textColor="@color/black"
                     android:textSize="24sp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    tools:text="13" />
+                    tools:text="4회" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -279,22 +271,24 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:layout_marginEnd="52dp"
             android:fontFamily="@font/pretendard_bold"
             android:text="@{@string/adventureResult_rank(viewModel.myRank)}"
             android:textColor="@color/black"
             android:textSize="28sp"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:layout_marginEnd="@dimen/space_default_medium"
             app:layout_constraintTop_toBottomOf="@+id/ll_adventureResult_window"
-            tools:text="123등" />
+            tools:text="123등"
+            app:layout_constraintEnd_toEndOf="@+id/ll_adventureResult_window"
+            app:layout_constraintBottom_toTopOf="@+id/btn_adventureResult_return"
+            app:layout_constraintVertical_bias="0.0" />
 
         <Button
             android:id="@+id/btn_adventureResult_return"
             android:layout_width="0dp"
-            android:layout_height="68dp"
+            android:layout_height="wrap_content"
             android:layout_marginStart="32dp"
             android:layout_marginEnd="32dp"
-            android:layout_marginBottom="12dp"
+            android:layout_marginBottom="@dimen/space_default_medium"
             android:fontFamily="@font/pretendard_bold"
             android:paddingVertical="@dimen/space_default_medium"
             android:text="@string/adventureResult_return_main"
@@ -302,7 +296,6 @@
             android:textSize="20sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="1.0"
             app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -38,6 +38,10 @@
     <string name="adventureResult_hint_description">HINT USES</string>
     <string name="adventureResult_try_description">TRY COUNT</string>
     <string name="adventureResult_score_description">Score</string>
+    <string name="adventureResult_play_time_value">%d분</string>
+    <string name="adventureResult_distance_value">%dm</string>
+    <string name="adventureResult_hint_value">%d개</string>
+    <string name="adventureResult_try_count_value">%d회</string>
     <string name="adventureResult_value">+%d</string>
     <string name="adventureResult_return_main">메인으로 돌아가기</string>
     <string name="adventureResult_rank">%d등</string>

--- a/android/domain/src/main/java/com/now/domain/model/AdventureResult.kt
+++ b/android/domain/src/main/java/com/now/domain/model/AdventureResult.kt
@@ -1,7 +1,6 @@
 package com.now.domain.model
 
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 data class AdventureResult(
     val id: Long,
@@ -9,7 +8,7 @@ data class AdventureResult(
     val destination: Place,
     val resultType: AdventureResultType,
     val score: Int,
-    val playTime: LocalTime,
+    val playTime: Int,
     val distance: Int,
     val hintUses: Int,
     val tryCount: Int,

--- a/android/domain/src/main/java/com/now/domain/model/Statistics.kt
+++ b/android/domain/src/main/java/com/now/domain/model/Statistics.kt
@@ -1,12 +1,10 @@
 package com.now.domain.model
 
-import java.time.LocalTime
-
 data class Statistics(
     val adventureCount: Int,
     val successCount: Int,
     val failureCount: Int,
     val totalDistance: Int,
-    val totalPlayTime: LocalTime,
+    val totalPlayTime: Int,
     val totalHintUses: Int,
 )


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #172 

## 🛠️ 작업 내용
- [x] Dto의 playTime의 타입이 LocalTime에서 Int로 변경
- [x] 도메인의 playTime의 타입이 LocalTime에서 Int로 변경
- [x] 매퍼 변경
- [x] 게임 결과 뷰 디자인 일부 수정 (단위를 추가, 제약 수정)

## 🎯 리뷰 포인트
지금 너무 api에 의존적인 도메인인 것 같아서 종종 현타가 오네요
나중에 도메인이 자립할 수 있도록 수정해봅시다,,
ex) AdventureResult 도메인에 startDateTime과 endDateTime이 존재하므로 playTime 필드를 지운다. (계산 가능)
그랬다면 이번 수정에서 도메인 수정을 하지 않을 수 있었겠죠?

게임 결과 뷰에서는 수정이 조금 있었지만 마이페이지에선 presentation단의 수정사항은 없었습니다. (toUi 매퍼 제외)

## ⏳ 작업 시간
추정 시간:   30h
실제 시간:   1h
뷰의 수정도 추가되면서 조금 더 오래걸렸습니다.
