### PR TITLE
[BE] feat: 게임 종료 시, 플레이어 점수 덧셈 기능 추가

### DIFF
--- a/backend/src/main/java/com/now/naaga/game/application/GameService.java
+++ b/backend/src/main/java/com/now/naaga/game/application/GameService.java
@@ -60,19 +60,16 @@ public class GameService {
         final Game game = new Game(player, place, position);
         return gameRepository.save(game);
     }
-
+    
     public void endGame(final EndGameCommand endGameCommand) {
         final Game game = gameRepository.findById(endGameCommand.gameId())
                 .orElseThrow(() -> new GameException(NOT_EXIST));
         final Player player = playerService.findPlayerById(endGameCommand.playerId());
         game.validateOwner(player);
         ResultType resultType = game.endGame(endGameCommand.endType(), endGameCommand.position());
-        gameResultRepository.save(createGameResult(resultType, game));
-    }
-
-    private GameResult createGameResult(final ResultType resultType, final Game game) {
         Score score = scorePolicy.calculate(game);
-        return new GameResult(resultType, score, game);
+        player.addScore(score);
+        gameResultRepository.save(new GameResult(resultType, score, game));
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
@@ -118,7 +118,7 @@ public class GameController {
 
         final List<GameRecord> gameRecords = gameService.findAllGameResult(playerRequest);
         final List<GameResultResponse> gameResultResponseList = gameRecords.stream()
-                .map(GameResultResponse::from)
+                .map(GameResultResponse::fromToMeter)
                 .collect(Collectors.toList());
 
         return ResponseEntity

--- a/backend/src/main/java/com/now/naaga/game/presentation/dto/GameResultResponse.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/dto/GameResultResponse.java
@@ -31,4 +31,19 @@ public record GameResultResponse(Long id,
                 gameRecord.getStartTime(),
                 gameRecord.getFinishTime());
     }
+    
+    public static GameResultResponse fromToMeter(final GameRecord gameRecord) {
+        return new GameResultResponse(
+                gameRecord.getGameResult().getId(),
+                gameRecord.getGameResult().getGame().getId(),
+                GameDestinationResponse.from(gameRecord.getGameResult().getGame().getPlace()),
+                gameRecord.getGameResult().getResultType(),
+                gameRecord.getGameResult().getScore().getValue(),
+                gameRecord.durationToInteger(gameRecord.getTotalPlayTime()),
+                gameRecord.getDistance()*1000,
+                gameRecord.getHintUses(),
+                gameRecord.getTryCount(),
+                gameRecord.getStartTime(),
+                gameRecord.getFinishTime());
+    }
 }

--- a/backend/src/main/java/com/now/naaga/player/domain/Player.java
+++ b/backend/src/main/java/com/now/naaga/player/domain/Player.java
@@ -51,6 +51,10 @@ public class Player extends BaseEntity {
         this.totalScore = totalScore;
         this.member = member;
     }
+    
+    public void addScore(Score score) {
+        this.totalScore = this.totalScore.plus(score);
+    }
 
     public Long getId() {
         return id;

--- a/backend/src/main/java/com/now/naaga/score/domain/Score.java
+++ b/backend/src/main/java/com/now/naaga/score/domain/Score.java
@@ -20,6 +20,10 @@ public class Score {
     public boolean isHigherThan(Score other) {
         return this.value > other.value;
     }
+    
+    public Score plus(Score score) {
+        return new Score(this.value+ score.value);
+    }
 
     public int getValue() {
         return value;


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #197 

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] 게임 종료 시, 플레이어 점수 덧셈 기능 추가
- [x] 게임 결과 거리 조회 수정

## ⏳ 작업 시간
추정 시간:   20m
실제 시간:   20m