### PR TITLE
fix: AuthInfo에 기본 생성자 추가

### DIFF
--- a/backend/src/main/java/com/now/naaga/auth/application/dto/AuthInfo.java
+++ b/backend/src/main/java/com/now/naaga/auth/application/dto/AuthInfo.java
@@ -2,22 +2,23 @@ package com.now.naaga.auth.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Objects;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class AuthInfo {
 
     @JsonProperty("kakao_account")
     private KakaoAccount kakaoAccount;
+
+    public AuthInfo() {
+    }
 
     public AuthInfo(final KakaoAccount kakaoAccount) {
         this.kakaoAccount = kakaoAccount;
     }
 
     public static AuthInfo of(final String email,
-                       final String nickname) {
+                              final String nickname) {
         final KakaoProfile kakaoProfile = new KakaoProfile(nickname);
         final KakaoAccount kakaoAccount = new KakaoAccount(kakaoProfile, email);
         return new AuthInfo(kakaoAccount);
@@ -29,6 +30,9 @@ public class AuthInfo {
         private KakaoProfile profile;
 
         private String email;
+
+        public KakaoAccount() {
+        }
 
         public KakaoAccount(final KakaoProfile profile,
                             final String email) {
@@ -71,6 +75,9 @@ public class AuthInfo {
     static class KakaoProfile {
 
         private String nickname;
+
+        public KakaoProfile() {
+        }
 
         public KakaoProfile(final String nickname) {
             this.nickname = nickname;

--- a/backend/src/main/java/com/now/naaga/auth/infrastructure/AuthClient.java
+++ b/backend/src/main/java/com/now/naaga/auth/infrastructure/AuthClient.java
@@ -39,7 +39,7 @@ public class AuthClient {
 
         try {
             return restTemplate.postForObject(url, request, AuthInfo.class);
-        } catch (HttpClientErrorException e) {
+        } catch (Exception e) {
             throw new AuthException(AuthExceptionType.INVALID_KAKAO_INFO);
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #246 

## 🛠️ 작업 내용
- [x] AuthInfo 기본 생성자 추가

## 🎯 리뷰 포인트
restTemplate.postForObject()에서 JSON을 객체로 파싱하는 과정에서 기본 생성자 없어서 안됐던 부분 추가

## ⏳ 작업 시간
추정 시간: 10분
실제 시간:  30분
이유: 왜 안되는지 명확히 알기 어려운 문제였다
