### PR TITLE
[AN] feat: 이어하기 기능 추가

### DIFF
--- a/android/.editorconfig
+++ b/android/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = crlf
+end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true

--- a/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultActivity.kt
@@ -14,6 +14,7 @@ import com.now.naaga.data.firebase.analytics.AnalyticsDelegate
 import com.now.naaga.data.firebase.analytics.DefaultAnalyticsDelegate
 import com.now.naaga.data.firebase.analytics.RESULT_RESULT_RETURN
 import com.now.naaga.databinding.ActivityAdventureResultBinding
+import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 
 class AdventureResultActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalyticsDelegate() {
     private lateinit var binding: ActivityAdventureResultBinding
@@ -88,6 +89,7 @@ class AdventureResultActivity : AppCompatActivity(), AnalyticsDelegate by Defaul
     private fun setClickListeners() {
         binding.btnAdventureResultReturn.setOnClickListener {
             logClickEvent(getViewEntryName(it), RESULT_RESULT_RETURN)
+            startActivity(BeginAdventureActivity.getIntent(this))
             finish()
         }
     }

--- a/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
@@ -104,12 +104,12 @@ class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by Default
             startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
             Toast.makeText(this, GPS_TURN_ON_MESSAGE, Toast.LENGTH_SHORT).show()
         } else {
-            startActivity(getExistingAdventure())
+            startActivity(getIntentWithAdventureOrWithout())
             finish()
         }
     }
 
-    private fun getExistingAdventure(): Intent {
+    private fun getIntentWithAdventureOrWithout(): Intent {
         val existingAdventure = intent.getParcelable(ADVENTURE, AdventureUiModel::class.java)?.toDomain()
 
         return if (existingAdventure == null) {

--- a/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
@@ -54,6 +54,7 @@ class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by Default
         binding = ActivityBeginAdventureBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        setBeginText()
         registerAnalytics(this.lifecycle)
         requestLocationPermission()
         setClickListeners()
@@ -68,6 +69,16 @@ class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by Default
                 ),
             )
         }
+    }
+
+    private fun setBeginText() {
+        if (getParcelableAdventure() != null) {
+            binding.tvBeginAdventureBegin.text = getString(R.string.beginAdventure_continue_adventure)
+        }
+    }
+
+    private fun getParcelableAdventure(): AdventureUiModel? {
+        return intent.getParcelable(ADVENTURE, AdventureUiModel::class.java)
     }
 
     private fun setClickListeners() {
@@ -110,7 +121,7 @@ class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by Default
     }
 
     private fun getIntentWithAdventureOrWithout(): Intent {
-        val existingAdventure = intent.getParcelable(ADVENTURE, AdventureUiModel::class.java)?.toDomain()
+        val existingAdventure = getParcelableAdventure()?.toDomain()
 
         return if (existingAdventure == null) {
             OnAdventureActivity.getIntent(this)

--- a/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
@@ -26,7 +26,7 @@ import com.now.naaga.presentation.rank.RankActivity
 import com.now.naaga.presentation.uimodel.mapper.toDomain
 import com.now.naaga.presentation.uimodel.mapper.toUi
 import com.now.naaga.presentation.uimodel.model.AdventureUiModel
-import com.now.naaga.util.getParcelable
+import com.now.naaga.util.getParcelableCompat
 
 class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalyticsDelegate() {
     private lateinit var binding: ActivityBeginAdventureBinding
@@ -78,7 +78,7 @@ class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by Default
     }
 
     private fun getParcelableAdventure(): AdventureUiModel? {
-        return intent.getParcelable(ADVENTURE, AdventureUiModel::class.java)
+        return intent.getParcelableCompat(ADVENTURE, AdventureUiModel::class.java)
     }
 
     private fun setClickListeners() {

--- a/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
@@ -10,6 +10,7 @@ import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import com.now.domain.model.Adventure
 import com.now.naaga.R
 import com.now.naaga.data.firebase.analytics.AnalyticsDelegate
 import com.now.naaga.data.firebase.analytics.BEGIN_BEGIN_ADVENTURE
@@ -22,6 +23,10 @@ import com.now.naaga.presentation.beginadventure.LocationPermissionDialog.Compan
 import com.now.naaga.presentation.mypage.MyPageActivity
 import com.now.naaga.presentation.onadventure.OnAdventureActivity
 import com.now.naaga.presentation.rank.RankActivity
+import com.now.naaga.presentation.uimodel.mapper.toDomain
+import com.now.naaga.presentation.uimodel.mapper.toUi
+import com.now.naaga.presentation.uimodel.model.AdventureUiModel
+import com.now.naaga.util.getParcelable
 
 class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalyticsDelegate() {
     private lateinit var binding: ActivityBeginAdventureBinding
@@ -99,15 +104,33 @@ class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by Default
             startActivity(Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS))
             Toast.makeText(this, GPS_TURN_ON_MESSAGE, Toast.LENGTH_SHORT).show()
         } else {
-            startActivity(OnAdventureActivity.getIntent(this))
+            startActivity(getExistingAdventure())
+            finish()
+        }
+    }
+
+    private fun getExistingAdventure(): Intent {
+        val existingAdventure = intent.getParcelable(ADVENTURE, AdventureUiModel::class.java)?.toDomain()
+
+        return if (existingAdventure == null) {
+            OnAdventureActivity.getIntent(this)
+        } else {
+            OnAdventureActivity.getIntentWithAdventure(this, existingAdventure)
         }
     }
 
     companion object {
         private const val GPS_TURN_ON_MESSAGE = "GPS 설정을 켜주세요"
+        private const val ADVENTURE = "ADVENTURE"
 
         fun getIntent(context: Context): Intent {
             return Intent(context, BeginAdventureActivity::class.java)
+        }
+
+        fun getIntentWithAdventure(context: Context, adventure: Adventure): Intent {
+            return Intent(context, BeginAdventureActivity::class.java).apply {
+                putExtra(ADVENTURE, adventure.toUi())
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
@@ -17,7 +17,7 @@ import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import com.now.naaga.presentation.uimodel.mapper.toDomain
 import com.now.naaga.presentation.uimodel.mapper.toUi
 import com.now.naaga.presentation.uimodel.model.AdventureUiModel
-import com.now.naaga.util.getParcelable
+import com.now.naaga.util.getParcelableCompat
 import com.now.naaga.util.loginWithKakao
 
 class LoginActivity : AppCompatActivity() {
@@ -66,7 +66,7 @@ class LoginActivity : AppCompatActivity() {
     }
 
     private fun navigateHome() {
-        val adventure = intent.getParcelable(ADVENTURE, AdventureUiModel::class.java)?.toDomain()
+        val adventure = intent.getParcelableCompat(ADVENTURE, AdventureUiModel::class.java)?.toDomain()
 
         val intent = if (adventure == null) {
             BeginAdventureActivity.getIntent(this)

--- a/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
@@ -7,12 +7,17 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.ViewModelProvider
+import com.now.domain.model.Adventure
 import com.now.domain.model.AuthPlatformType
 import com.now.naaga.NaagaApplication
 import com.now.naaga.R
 import com.now.naaga.data.repository.DefaultAuthRepository
 import com.now.naaga.databinding.ActivityLoginBinding
 import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
+import com.now.naaga.presentation.uimodel.mapper.toDomain
+import com.now.naaga.presentation.uimodel.mapper.toUi
+import com.now.naaga.presentation.uimodel.model.AdventureUiModel
+import com.now.naaga.util.getParcelable
 import com.now.naaga.util.loginWithKakao
 
 class LoginActivity : AppCompatActivity() {
@@ -61,13 +66,29 @@ class LoginActivity : AppCompatActivity() {
     }
 
     private fun navigateHome() {
-        startActivity(BeginAdventureActivity.getIntent(this))
+        val adventure = intent.getParcelable(ADVENTURE, AdventureUiModel::class.java)?.toDomain()
+
+        val intent = if (adventure == null) {
+            BeginAdventureActivity.getIntent(this)
+        } else {
+            BeginAdventureActivity.getIntentWithAdventure(this, adventure)
+        }
+
+        startActivity(intent)
         finish()
     }
 
     companion object {
+        private const val ADVENTURE = "ADVENTURE"
+
         fun getIntent(context: Context): Intent {
             return Intent(context, LoginActivity::class.java)
+        }
+
+        fun getIntentWithAdventure(context: Context, adventure: Adventure): Intent {
+            return Intent(context, LoginActivity::class.java).apply {
+                putExtra(ADVENTURE, adventure.toUi())
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -42,6 +43,7 @@ class OnAdventureActivity :
         initViewModel()
         subscribe()
         setOnMapReady { setLocationChangeListener() }
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
         setClickListeners()
     }
 
@@ -49,6 +51,19 @@ class OnAdventureActivity :
         viewModel = ViewModelProvider(this, OnAdventureViewModel.Factory)[OnAdventureViewModel::class.java]
         binding.viewModel = viewModel
         binding.lifecycleOwner = this
+    }
+
+    private var backPressedTime = 0L
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (System.currentTimeMillis() - backPressedTime <= 2000) {
+                finish()
+            } else {
+                backPressedTime = System.currentTimeMillis()
+                Toast.makeText(this@OnAdventureActivity, "뒤로가기 버튼을 한번 더 누르면 게임에서 나가져요!", Toast.LENGTH_SHORT)
+                    .show()
+            }
+        }
     }
 
     private fun setClickListeners() {

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -60,7 +60,11 @@ class OnAdventureActivity :
                 finish()
             } else {
                 backPressedTime = System.currentTimeMillis()
-                Toast.makeText(this@OnAdventureActivity, "뒤로가기 버튼을 한번 더 누르면 게임에서 나가져요!", Toast.LENGTH_SHORT)
+                Toast.makeText(
+                    this@OnAdventureActivity,
+                    getString(R.string.OnAdventure_warning_back_pressed),
+                    Toast.LENGTH_SHORT,
+                )
                     .show()
             }
         }
@@ -119,7 +123,7 @@ class OnAdventureActivity :
             return
         }
 
-        Toast.makeText(this, "진행중인 게임에 입장했습니다.", Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, getString(R.string.OnAdventure_continue_adventure), Toast.LENGTH_SHORT).show()
         viewModel.setAdventure(existingAdventure)
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -25,7 +25,7 @@ import com.now.naaga.presentation.adventureresult.AdventureResultActivity
 import com.now.naaga.presentation.uimodel.mapper.toDomain
 import com.now.naaga.presentation.uimodel.mapper.toUi
 import com.now.naaga.presentation.uimodel.model.AdventureUiModel
-import com.now.naaga.util.getParcelable
+import com.now.naaga.util.getParcelableCompat
 
 class OnAdventureActivity :
     AppCompatActivity(),
@@ -112,7 +112,7 @@ class OnAdventureActivity :
     }
 
     private fun beginAdventure(coordinate: Coordinate) {
-        val existingAdventure = intent.getParcelable(ADVENTURE, AdventureUiModel::class.java)?.toDomain()
+        val existingAdventure = intent.getParcelableCompat(ADVENTURE, AdventureUiModel::class.java)?.toDomain()
 
         if (existingAdventure == null) {
             viewModel.beginAdventure(coordinate)

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -103,6 +103,8 @@ class OnAdventureActivity :
             viewModel.beginAdventure(coordinate)
             return
         }
+
+        Toast.makeText(this, "진행중인 게임에 입장했습니다.", Toast.LENGTH_SHORT).show()
         viewModel.setAdventure(existingAdventure)
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
@@ -10,7 +10,6 @@ import com.now.domain.model.AdventureStatus.DONE
 import com.now.domain.model.AdventureStatus.IN_PROGRESS
 import com.now.domain.model.AdventureStatus.NONE
 import com.now.naaga.R
-import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import com.now.naaga.presentation.login.LoginActivity
 
 class SplashActivity : AppCompatActivity() {
@@ -36,14 +35,7 @@ class SplashActivity : AppCompatActivity() {
 
     private fun startNextActivity(adventureStatus: AdventureStatus) {
         val intent: Intent = when (adventureStatus) {
-            IN_PROGRESS -> {
-                val adventure = viewModel.adventure.value
-                if (adventure == null) {
-                    BeginAdventureActivity.getIntent(this)
-                } else {
-                    BeginAdventureActivity.getIntentWithAdventure(this, adventure)
-                }
-            }
+            IN_PROGRESS -> LoginActivity.getIntent(this)
             DONE -> LoginActivity.getIntent(this)
             NONE -> LoginActivity.getIntent(this)
         }

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
@@ -1,14 +1,10 @@
 package com.now.naaga.presentation.splash
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.ViewModelProvider
 import com.now.domain.model.AdventureStatus
-import com.now.domain.model.AdventureStatus.DONE
-import com.now.domain.model.AdventureStatus.IN_PROGRESS
-import com.now.domain.model.AdventureStatus.NONE
 import com.now.naaga.R
 import com.now.naaga.presentation.login.LoginActivity
 
@@ -34,10 +30,12 @@ class SplashActivity : AppCompatActivity() {
     }
 
     private fun startNextActivity(adventureStatus: AdventureStatus) {
-        val intent: Intent = when (adventureStatus) {
-            IN_PROGRESS -> LoginActivity.getIntent(this)
-            DONE -> LoginActivity.getIntent(this)
-            NONE -> LoginActivity.getIntent(this)
+        val adventure = viewModel.adventure.value
+
+        val intent = if (adventure == null) {
+            LoginActivity.getIntent(this)
+        } else {
+            LoginActivity.getIntentWithAdventure(this, adventure)
         }
         startActivity(intent)
         finish()

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
@@ -12,7 +12,6 @@ import com.now.domain.model.AdventureStatus.NONE
 import com.now.naaga.R
 import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import com.now.naaga.presentation.login.LoginActivity
-import com.now.naaga.presentation.onadventure.OnAdventureActivity
 
 class SplashActivity : AppCompatActivity() {
     private lateinit var viewModel: SplashViewModel
@@ -42,7 +41,7 @@ class SplashActivity : AppCompatActivity() {
                 if (adventure == null) {
                     BeginAdventureActivity.getIntent(this)
                 } else {
-                    OnAdventureActivity.getIntentWithAdventure(this, adventure)
+                    BeginAdventureActivity.getIntentWithAdventure(this, adventure)
                 }
             }
             DONE -> LoginActivity.getIntent(this)

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashViewModel.kt
@@ -11,7 +11,7 @@ import com.now.naaga.data.repository.DefaultAdventureRepository
 
 class SplashViewModel(private val adventureRepository: AdventureRepository) : ViewModel() {
     private val _adventure = MutableLiveData<Adventure>()
-    val adventure: LiveData<Adventure> get() = _adventure
+    val adventure: LiveData<Adventure> = _adventure
 
     private val _adventureStatus = MutableLiveData<AdventureStatus>()
     val adventureStatus: LiveData<AdventureStatus> = _adventureStatus

--- a/android/app/src/main/java/com/now/naaga/util/IntentExt.kt
+++ b/android/app/src/main/java/com/now/naaga/util/IntentExt.kt
@@ -3,7 +3,7 @@ package com.now.naaga.util
 import android.content.Intent
 import android.os.Build
 
-fun <T> Intent.getParcelable(key: String, data: Class<T>): T? {
+fun <T> Intent.getParcelableCompat(key: String, data: Class<T>): T? {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         getParcelableExtra(key, data)
     } else {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="beginAdventure_approximate_access">대략적인 위치 권한만 허용되었습니다</string>
     <string name="beginAdventure_denied_access">위치 권한 요청이 거절되었습니다</string>
     <string name="beginAdventure_features_not_ready">아직 준비되지 않은 기능입니다.</string>
+    <string name="beginAdventure_continue_adventure">이어 하기</string>
 
     <!-- LocationDialog-->
     <string name="locationDialog_setting">설정으로 이동해요</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@
     <string name="onAdventure_begin_error">모험 시작에 실패했어요. 다시 시작해주세요</string>
     <string name="onAdventure_no_more_hint">힌트를 모두 소진하였어요</string>
     <string name="onAdventure_unexpected_error">알 수 없는 오류가 발생했어요</string>
+    <string name="OnAdventure_continue_adventure">진행중인 게임에 입장했어요!</string>
+    <string name="OnAdventure_warning_back_pressed">뒤로가기 버튼을 한번 더 누르면 게임에서 나가져요!</string>
 
     <!-- AdventureResultActivity -->
     <string name="adventureResult_destination_description">오늘의 목적지</string>


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #248 

## 🛠️ 작업 내용
- [x] 이어하기 기능 추가
- [x] OnAdventureActivity에서 뒤로가기 버튼을 2초 이내에 2번 연속 눌려야 앱이 종료되도록 함
- [x] 게임 결과 화면에서 메인으로 돌아가기를 클릭했을 때 BeginActivity가 열림 

## 🎯 리뷰 포인트
- 현재는 splash에서 얻어온 Adventure를 Splash > Login > BeginAdventure > OnAdventure 이렇게 넘겨주고 있어요.
- BeginAdventureActivity에서 게임의 Status로 조회를 해서 데이터가 있다면 텍스트를 '이어하기'로 바꿔줘도 되겠지만 이 경우 서버통신이 종료되기 전까지는 '모험하기' 였다가 통신이 완료되고 진행중인 게임이 있는 것을 확인하면 '이어하기'로 변경되는데 이 흐름이 굉장히 어색해요. 더 자연스러운 흐름이 있을까요?


## ⏳ 작업 시간
추정 시간: 2h  
실제 시간: 4h  

- 이유 : 로직의 고민을 많이했다. 근데 결과적으로 원래대로 돌아왔다..;;