### PR TITLE
feat: 장소 업로드 기능 구현

### DIFF
--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/PlaceService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/PlaceService.kt
@@ -8,6 +8,7 @@ import retrofit2.http.GET
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.PartMap
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -26,9 +27,7 @@ interface PlaceService {
     @Multipart
     @POST("/places")
     fun registerPlace(
-        @Part name: RequestBody,
-        @Part description: RequestBody,
-        @Part coordinate: RequestBody,
+        @PartMap postData: Map<String, RequestBody>,
         @Part imageFile: MultipartBody.Part,
     ): Call<PlaceDto>
 }

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/PlaceService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/PlaceService.kt
@@ -27,7 +27,7 @@ interface PlaceService {
     @Multipart
     @POST("/places")
     fun registerPlace(
-        @PartMap postData: Map<String, RequestBody>,
+        @PartMap postData: HashMap<String, RequestBody>,
         @Part imageFile: MultipartBody.Part,
     ): Call<PlaceDto>
 }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultPlaceRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultPlaceRepository.kt
@@ -59,15 +59,10 @@ class DefaultPlaceRepository : PlaceRepository {
         )
 
         val postData = HashMap<String, RequestBody>()
-        val nameRequestBody = name.toRequestBody("text/plain".toMediaTypeOrNull())
-        val descriptionRequestBody = description.toRequestBody("text/plain".toMediaTypeOrNull())
-        val latitudeRequestBody = coordinate.latitude.toString().toRequestBody("text/plain".toMediaTypeOrNull())
-        val longitudeRequestBody = coordinate.longitude.toString().toRequestBody("text/plain".toMediaTypeOrNull())
-
-        postData["name"] = nameRequestBody
-        postData["description"] = descriptionRequestBody
-        postData["latitude"] = latitudeRequestBody
-        postData["longitude"] = longitudeRequestBody
+        postData["name"] = name.toRequestBody("text/plain".toMediaTypeOrNull())
+        postData["description"] = description.toRequestBody("text/plain".toMediaTypeOrNull())
+        postData["latitude"] = coordinate.latitude.toString().toRequestBody("text/plain".toMediaTypeOrNull())
+        postData["longitude"] = coordinate.longitude.toString().toRequestBody("text/plain".toMediaTypeOrNull())
 
         val call = placeService.registerPlace(postData, imagePart)
 

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultPlaceRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultPlaceRepository.kt
@@ -53,16 +53,16 @@ class DefaultPlaceRepository : PlaceRepository {
         val file = File(image)
         val requestFile = file.asRequestBody("image/jpeg".toMediaTypeOrNull())
         val imagePart = MultipartBody.Part.createFormData(
-            "imageFile",
+            KEY_IMAGE_FILE,
             file.name,
             requestFile,
         )
 
         val postData = HashMap<String, RequestBody>()
-        postData["name"] = name.toRequestBody("text/plain".toMediaTypeOrNull())
-        postData["description"] = description.toRequestBody("text/plain".toMediaTypeOrNull())
-        postData["latitude"] = coordinate.latitude.toString().toRequestBody("text/plain".toMediaTypeOrNull())
-        postData["longitude"] = coordinate.longitude.toString().toRequestBody("text/plain".toMediaTypeOrNull())
+        postData[KEY_NAME] = name.toRequestBody("text/plain".toMediaTypeOrNull())
+        postData[KEY_DESCRIPTION] = description.toRequestBody("text/plain".toMediaTypeOrNull())
+        postData[KEY_LATITUDE] = coordinate.latitude.toString().toRequestBody("text/plain".toMediaTypeOrNull())
+        postData[KEY_LONGITUDE] = coordinate.longitude.toString().toRequestBody("text/plain".toMediaTypeOrNull())
 
         val call = placeService.registerPlace(postData, imagePart)
 
@@ -74,5 +74,13 @@ class DefaultPlaceRepository : PlaceRepository {
                 callback(Result.failure(it))
             },
         )
+    }
+
+    companion object {
+        const val KEY_NAME = "name"
+        const val KEY_DESCRIPTION = "description"
+        const val KEY_LATITUDE = "latitude"
+        const val KEY_LONGITUDE = "longitude"
+        const val KEY_IMAGE_FILE = "imageFile"
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
@@ -26,6 +26,7 @@ import com.now.naaga.presentation.beginadventure.LocationPermissionDialog.Compan
 import com.now.naaga.presentation.mypage.MyPageActivity
 import com.now.naaga.presentation.onadventure.OnAdventureActivity
 import com.now.naaga.presentation.rank.RankActivity
+import com.now.naaga.presentation.upload.UploadActivity
 
 class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalyticsDelegate() {
     private lateinit var binding: ActivityBeginAdventureBinding
@@ -125,8 +126,7 @@ class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by Default
         }
         binding.ivBeginAdventureUpload.setOnClickListener {
             logClickEvent(getViewEntryName(it), BEGIN_GO_UPLOAD)
-            Toast.makeText(this, getString(R.string.beginAdventure_features_not_ready), Toast.LENGTH_SHORT).show()
-//            startActivity(UploadActivity.getIntent(this))
+            startActivity(UploadActivity.getIntent(this))
         }
         binding.ivBeginAdventureMypage.setOnClickListener {
             logClickEvent(getViewEntryName(it), BEGIN_GO_MYPAGE)

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
@@ -160,7 +160,7 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
         }
         binding.btnUploadSubmit.setOnClickListener {
             if (isFormValid().not()) {
-                shortToast("모든 정보를 입력해주세요.")
+                shortToast(getString(R.string.upload_error_insufficient_info_message))
             } else {
                 viewModel.postPlace()
             }

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadViewModel.kt
@@ -12,6 +12,8 @@ import com.now.domain.model.Coordinate
 import com.now.domain.model.Place
 import com.now.domain.repository.PlaceRepository
 import com.now.naaga.data.throwable.DataThrowable
+import com.now.naaga.data.throwable.DataThrowable.PlaceThrowable
+import com.now.naaga.data.throwable.DataThrowable.UniversalThrowable
 
 class UploadViewModel(
     private val application: Application,
@@ -65,9 +67,17 @@ class UploadViewModel(
             callback = { result: Result<Place> ->
                 result
                     .onSuccess { _successUpload.value = true }
-                    .onFailure { _throwable.value = it as DataThrowable }
+                    .onFailure { setError(it as DataThrowable) }
             },
         )
+    }
+
+    private fun setError(throwable: DataThrowable) {
+        when (throwable) {
+            is UniversalThrowable -> _throwable.value = throwable
+            is PlaceThrowable -> _throwable.value = throwable
+            else -> {}
+        }
     }
 
     private fun getAbsolutePathFromUri(context: Context, uri: Uri): String? {
@@ -84,5 +94,9 @@ class UploadViewModel(
 
     companion object {
         val DEFAULT_COORDINATE = Coordinate(-1.0, -1.0)
+
+        const val ALREADY_EXISTS_NEARBY = 505
+        const val ERROR_STORE_PHOTO = 215
+        const val ERROR_POST_BODY = 205
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.ViewModel
 import com.now.domain.model.Coordinate
 import com.now.domain.model.Place
 import com.now.domain.repository.PlaceRepository
+import com.now.naaga.data.throwable.DataThrowable
 
 class UploadViewModel(
     private val application: Application,
@@ -24,6 +25,12 @@ class UploadViewModel(
 
     private val _description = MutableLiveData<String>()
     val description: LiveData<String> = _description
+
+    private val _successUpload = MutableLiveData<Boolean>()
+    val successUpload: LiveData<Boolean> = _successUpload
+
+    private val _throwable = MutableLiveData<DataThrowable>()
+    val throwable: LiveData<DataThrowable> = _throwable
 
     fun setTitle(editTitle: Editable) {
         _name.value = editTitle.toString()
@@ -57,8 +64,8 @@ class UploadViewModel(
             image = getAbsolutePathFromUri(application.applicationContext, imageUri) ?: "",
             callback = { result: Result<Place> ->
                 result
-                    .onSuccess { }
-                    .onFailure { }
+                    .onSuccess { _successUpload.value = true }
+                    .onFailure { _throwable.value = it as DataThrowable }
             },
         )
     }

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -104,4 +104,5 @@
     <string name="upload_error_store_photo_message">사진을 저장하는데 문제가 생겼어요! 다시 시도해주세요!</string>
     <string name="upload_error_already_exists_nearby_message">근방에 다른 미션장소가 존재해서 추가할 수 없어요!</string>
     <string name="upload_error_post_message">전송에 실패했어요! 다시 시도해주세요!</string>
+    <string name="upload_error_insufficient_info_message">모든 정보를 입력해주세요.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -99,4 +99,9 @@
 
     <!-- LoginActivity -->
     <string name="login_app_title">NAAGA</string>
+
+    <!-- UploadActivity -->
+    <string name="upload_error_store_photo_message">사진을 저장하는데 문제가 생겼어요! 다시 시도해주세요!</string>
+    <string name="upload_error_already_exists_nearby_message">근방에 다른 미션장소가 존재해서 추가할 수 없어요!</string>
+    <string name="upload_error_post_message">전송에 실패했어요! 다시 시도해주세요!</string>
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #286 

## 🛠️ 작업 내용
장소 추가 기능 구현
- [x] Part로 보내던 데이터를 PartMap으로 변경한다.
- [x] 사진과 다른 정보들을 함께 업로드 하는 기능을 구현한다.
- [x] 핸들링 할 에러를 뷰모델에서 결정하고 액티비티에서 적절하게 핸들링한다. 

## 🎯 리뷰 포인트
### PlaceService
`@PartMap` 애노테이션을 통해 여러 개의 RequestBody를 묶어 한번에 보낼 수 있도록 기능을 구현했어요. 이런 방식으로 진행하면 POST 요청에서 서버에 보내야 하는 값이 하나 더 추가되더라도 PartMap에 추가만 해주면 되기 때문에 변경에 유연하다고 느껴집니다.

### DefaultPlaceRepository
String을 RequestBody로 바꿔 HashMap에 추가하여 PlaceService의 registerPlace 함수의 인자로 넣어줘요.  
이 때 PlaceService의 PartMap의 자료형을 Map으로 두고 DefaultPlaceRepository에서는 HashMap에 넣어줘서 보내니 아래와 같은 에러가 발생하더라구요. 그래서 HashMap으로 수정해주었습니다.
![image](https://github.com/woowacourse-teams/2023-naaga/assets/84285337/a152bc4f-cd61-4f72-9d47-34b97e60b215)
| 에러 해결 방법 : https://github.com/square/retrofit/issues/3275
정확한 이유는 더 찾아봐야 함

### UploadViewModel
DataThrowable로 반환된 예외 중 인증관련(200번대 에러 코드)를 잡는 UniversalThrowable과 장소관련(500번대 에러 코드)를 잡는 PlaceThrowable만을 잡아 핸들링 하도록 구현했어요.
205번 에러 : 요청 바디 값이 잘못 된 경우
215번 에러 : 사진 저장에서 문제가 생긴 경우
505번 에러 : 주변에 이미 저장된 장소가 있는 경우

### UploadActivity
위에서 잡은 예외들의 에러코드에 따라 적절한 메시지를 토스트로 띄워주도록 구현했어요.

### 포인트
- 적절한 에러를 적절한 방법으로 핸들링 했다고 생각하시는지 궁금합니다. 더 좋은 핸들링 방법이 있을 것 같기도 해서요!

## ⏳ 작업 시간
추정 시간: 1h  
실제 시간: 1h 30m  

PR을 자세하게 적으려고 좀 노력해서 시간이 조금 더 걸린 것 같아요.  
이번 회의 이후로 PR을 최대한 자세히 적자고 했으니 코드 리뷰 외에도 PR 내용에 대해서도 리뷰해주면 좋을 것 같아요! (너무 자세하다 혹은 너무 내용이 적다 등도 OK)
