### PR TITLE
fix: 위치관련 버그 수정

### DIFF
--- a/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/beginadventure/BeginAdventureActivity.kt
@@ -26,6 +26,7 @@ import com.now.naaga.presentation.beginadventure.LocationPermissionDialog.Compan
 import com.now.naaga.presentation.mypage.MyPageActivity
 import com.now.naaga.presentation.onadventure.OnAdventureActivity
 import com.now.naaga.presentation.rank.RankActivity
+import com.now.naaga.presentation.upload.UploadActivity
 
 class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalyticsDelegate() {
     private lateinit var binding: ActivityBeginAdventureBinding
@@ -125,8 +126,7 @@ class BeginAdventureActivity : AppCompatActivity(), AnalyticsDelegate by Default
         }
         binding.ivBeginAdventureUpload.setOnClickListener {
             logClickEvent(getViewEntryName(it), BEGIN_GO_UPLOAD)
-            Toast.makeText(this, getString(R.string.beginAdventure_features_not_ready), Toast.LENGTH_SHORT).show()
-//            startActivity(UploadActivity.getIntent(this))
+            startActivity(UploadActivity.getIntent(this))
         }
         binding.ivBeginAdventureMypage.setOnClickListener {
             logClickEvent(getViewEntryName(it), BEGIN_GO_MYPAGE)

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
@@ -69,6 +69,7 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
         setContentView(binding.root)
 
         initViewModel()
+        subscribe()
         registerAnalytics(this.lifecycle)
         requestPermission()
         setCoordinate()
@@ -82,6 +83,12 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
         binding.lifecycleOwner = this
         binding.viewModel = viewModel
         setClickListeners()
+    }
+
+    private fun subscribe() {
+        viewModel.coordinate.observe(this) {
+            binding.lottieUploadLoading.visibility = View.GONE
+        }
     }
 
     private fun requestPermission() {

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.location.Location
-import android.location.LocationManager
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
@@ -17,6 +16,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.tasks.CancellationToken
+import com.google.android.gms.tasks.CancellationTokenSource
+import com.google.android.gms.tasks.OnTokenCanceledListener
 import com.now.domain.model.Coordinate
 import com.now.naaga.data.firebase.analytics.AnalyticsDelegate
 import com.now.naaga.data.firebase.analytics.DefaultAnalyticsDelegate
@@ -93,13 +96,27 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
 
     private fun setCoordinate() {
         if (checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-            val locationManager = getSystemService(LOCATION_SERVICE) as LocationManager
-            val location = locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER)
+            val fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
+            fusedLocationClient.getCurrentLocation(PRIORITY_HIGH_ACCURACY, createCancellationToken())
+                .addOnSuccessListener { location ->
+                    if (location != null) {
+                        val coordinate = getCoordinate(location)
+                        binding.tvUploadPhotoCoordinate.text = coordinate.toText()
+                        viewModel.setCoordinate(coordinate)
+                    }
+                }
+                .addOnFailureListener { }
+        }
+    }
 
-            if (location != null) {
-                val coordinate = getCoordinate(location)
-                binding.tvUploadPhotoCoordinate.text = coordinate.toText()
-                viewModel.setCoordinate(coordinate)
+    private fun createCancellationToken(): CancellationToken {
+        return object : CancellationToken() {
+            override fun onCanceledRequested(p0: OnTokenCanceledListener): CancellationToken {
+                return CancellationTokenSource().token
+            }
+
+            override fun isCancellationRequested(): Boolean {
+                return false
             }
         }
     }
@@ -216,6 +233,8 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
             put(MediaStore.Images.Media.DISPLAY_NAME, "ImageTitle")
             put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
         }
+
+        const val PRIORITY_HIGH_ACCURACY = 100
 
         fun getIntent(context: Context): Intent {
             return Intent(context, UploadActivity::class.java)

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadViewModel.kt
@@ -17,13 +17,15 @@ class UploadViewModel(
     private val placeRepository: PlaceRepository,
 ) : ViewModel() {
     private var imageUri: Uri = Uri.EMPTY
-    private var coordinate = DEFAULT_COORDINATE
 
     private val _name = MutableLiveData<String>()
     val title: LiveData<String> = _name
 
     private val _description = MutableLiveData<String>()
     val description: LiveData<String> = _description
+
+    private val _coordinate = MutableLiveData<Coordinate>()
+    val coordinate: LiveData<Coordinate> = _coordinate
 
     fun setTitle(editTitle: Editable) {
         _name.value = editTitle.toString()
@@ -38,7 +40,7 @@ class UploadViewModel(
     }
 
     fun setCoordinate(coordinate: Coordinate) {
-        this.coordinate = coordinate
+        _coordinate.value = coordinate
     }
 
     fun hasUri(): Boolean {
@@ -46,21 +48,23 @@ class UploadViewModel(
     }
 
     fun hasCoordinate(): Boolean {
-        return coordinate != DEFAULT_COORDINATE
+        return _coordinate.value != null
     }
 
     fun postPlace() {
-        placeRepository.postPlace(
-            name = _name.value.toString(),
-            description = _description.value.toString(),
-            coordinate = coordinate,
-            image = getAbsolutePathFromUri(application.applicationContext, imageUri) ?: "",
-            callback = { result: Result<Place> ->
-                result
-                    .onSuccess { }
-                    .onFailure { }
-            },
-        )
+        _coordinate.value?.let { coordinate ->
+            placeRepository.postPlace(
+                name = _name.value.toString(),
+                description = _description.value.toString(),
+                coordinate = coordinate,
+                image = getAbsolutePathFromUri(application.applicationContext, imageUri) ?: "",
+                callback = { result: Result<Place> ->
+                    result
+                        .onSuccess { }
+                        .onFailure { }
+                },
+            )
+        }
     }
 
     private fun getAbsolutePathFromUri(context: Context, uri: Uri): String? {
@@ -73,9 +77,5 @@ class UploadViewModel(
             }
         }
         return null
-    }
-
-    companion object {
-        val DEFAULT_COORDINATE = Coordinate(-1.0, -1.0)
     }
 }

--- a/android/app/src/main/res/layout/activity_upload.xml
+++ b/android/app/src/main/res/layout/activity_upload.xml
@@ -18,6 +18,21 @@
         android:layout_marginTop="@dimen/space_default_large"
         tools:context=".presentation.upload.UploadActivity">
 
+        <com.airbnb.lottie.LottieAnimationView
+            android:id="@+id/lottie_upload_loading"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="80dp"
+            android:elevation="4dp"
+            android:background="@color/main_gray_opacity_medium"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:lottie_rawRes="@raw/simple_loading"
+            app:lottie_loop="true"
+            app:lottie_autoPlay="true" />
+
         <ImageView
             android:id="@+id/iv_upload_photo"
             android:layout_width="180dp"


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #300 

## 🛠️ 작업 내용
- [x] 위치를 받아오는 방법 변경
- [x] 위치를 받아올 때까지 로티를 보여주는 기능 구현

## 🎯 리뷰 포인트
### 위치를 받아오는 방법 변경
기존에 LocationManager를 이용하여 위치를 가져왔었는데, 이 메서드를 통해 가져오는 위치 정보 값이 Null인 경우도 많고, 언제 업데이트 된 정보인지 알기 어려워서 FusedLocationProvider를 통해 값을 가져오는 방식으로 수정했습니다.

### 로티 추가
위치를 받아오는 메서드가 비동기로 실행되서 사용자에게 기다림이 필요하다는 것을 명시적으로 표시하기 위해 로딩 로티를 추가했어요.

### 위치 정보 저장 관련 내용
ViewModel이 위치 정보를 가지고 있는 상태에요. 이렇게 구현한 이유는 위치를 가져오는 메서드가 비동기로 실행인데요. 언제 값을 가져올지 모르기 때문에 유저에게 로딩 로티를 보여주고 값을 받아오면 로티가 보이지 않도록 변경하기 위함입니다.  

그래서 로직이 좀 이상한데요. 
액티비티가 뷰모델의 위치정보를 구독한다. → 액티비티에서 현재 위치를 가져온다. → 뷰모델에 넣어준다. → 뷰모델의 데이터가 변경됨을 감지해 로티를 없애준다.  

제가 생각한 최선의 방법인데요, 빅스가 생각했을 때 더 좋은 방법이 있다면 추천해줘도 됩니다.  
그리고 현재 뷰에 좌표를 보여주는 것이 과연 사용자에게 의미있는 행동일까도 좀 고민을 해봤어요. 빅스와 이야기 나눠보고 싶네요.

## ⏳ 작업 시간
추정 시간: 2h  
실제 시간: 2h  
