### PR TITLE
refactor: ViewModel이 Application을 참조하지 않도록 변경

### DIFF
--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
@@ -80,7 +80,7 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
 
     private fun initViewModel() {
         val repository = DefaultPlaceRepository()
-        val factory = UploadFactory(application, repository)
+        val factory = UploadFactory(repository)
         viewModel = ViewModelProvider(this, factory)[UploadViewModel::class.java]
         binding.lifecycleOwner = this
         binding.viewModel = viewModel
@@ -210,7 +210,7 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
     private fun setImage(bitmap: Bitmap) {
         binding.ivUploadCameraIcon.visibility = View.GONE
         binding.ivUploadPhoto.setImageBitmap(bitmap)
-        val uri = getImageUri(bitmap) ?: Uri.EMPTY
+        val uri = getAbsolutePathFromUri(getImageUri(bitmap) ?: Uri.EMPTY) ?: ""
         viewModel.setUri(uri)
     }
 
@@ -224,6 +224,18 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
                 }
                 return imageUri
             }
+        return null
+    }
+
+    private fun getAbsolutePathFromUri(uri: Uri): String? {
+        val projection = arrayOf(MediaStore.Images.Media.DATA)
+        val cursor = applicationContext.contentResolver.query(uri, projection, null, null, null)
+        cursor?.use {
+            val columnIndex = it.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
+            if (it.moveToFirst()) {
+                return it.getString(columnIndex)
+            }
+        }
         return null
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadFactory.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadFactory.kt
@@ -1,17 +1,15 @@
 package com.now.naaga.presentation.upload
 
-import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.now.domain.repository.PlaceRepository
 
 class UploadFactory(
-    private val application: Application,
     private val placeRepository: PlaceRepository,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(UploadViewModel::class.java)) {
-            return UploadViewModel(application, placeRepository) as T
+            return UploadViewModel(placeRepository) as T
         } else {
             throw java.lang.IllegalArgumentException()
         }

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadViewModel.kt
@@ -1,9 +1,6 @@
 package com.now.naaga.presentation.upload
 
-import android.app.Application
-import android.content.Context
 import android.net.Uri
-import android.provider.MediaStore
 import android.text.Editable
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -16,10 +13,9 @@ import com.now.naaga.data.throwable.DataThrowable.PlaceThrowable
 import com.now.naaga.data.throwable.DataThrowable.UniversalThrowable
 
 class UploadViewModel(
-    private val application: Application,
     private val placeRepository: PlaceRepository,
 ) : ViewModel() {
-    private var imageUri: Uri = Uri.EMPTY
+    private var imageUri: String = URI_EMPTY
 
     private val _name = MutableLiveData<String>()
     val title: LiveData<String> = _name
@@ -44,7 +40,7 @@ class UploadViewModel(
         _description.value = editTitle.toString()
     }
 
-    fun setUri(uri: Uri) {
+    fun setUri(uri: String) {
         imageUri = uri
     }
 
@@ -53,7 +49,7 @@ class UploadViewModel(
     }
 
     fun hasUri(): Boolean {
-        return imageUri != Uri.EMPTY
+        return imageUri != URI_EMPTY
     }
 
     fun hasCoordinate(): Boolean {
@@ -66,7 +62,7 @@ class UploadViewModel(
                 name = _name.value.toString(),
                 description = _description.value.toString(),
                 coordinate = coordinate,
-                image = getAbsolutePathFromUri(application.applicationContext, imageUri) ?: "",
+                image = imageUri,
                 callback = { result: Result<Place> ->
                     result
                         .onSuccess { _successUpload.value = true }
@@ -84,20 +80,8 @@ class UploadViewModel(
         }
     }
 
-    private fun getAbsolutePathFromUri(context: Context, uri: Uri): String? {
-        val projection = arrayOf(MediaStore.Images.Media.DATA)
-        val cursor = context.contentResolver.query(uri, projection, null, null, null)
-        cursor?.use {
-            val columnIndex = it.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
-            if (it.moveToFirst()) {
-                return it.getString(columnIndex)
-            }
-        }
-        return null
-    }
-
     companion object {
-        val DEFAULT_COORDINATE = Coordinate(-1.0, -1.0)
+        val URI_EMPTY = Uri.EMPTY.toString()
 
         const val ALREADY_EXISTS_NEARBY = 505
         const val ERROR_STORE_PHOTO = 215


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #306 

## 🛠️ 작업 내용
- [x] ViewModel이 Application을 참조하지 않도록 변경
- [x] 절대경로로 변경하는 작업을 Activity에서 하도록 변경

## 🎯 리뷰 포인트
ViewModel이 Application을 참조하지 않도록 변경을 잘 하였는가

## ⏳ 작업 시간
추정 시간: 20m  
실제 시간: 20m  