### PR TITLE
refactor: Adventure 도메인에 해당하는 네트워크 작업 코루틴으로 변경

### DIFF
--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AdventureService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AdventureService.kt
@@ -6,7 +6,7 @@ import com.now.naaga.data.remote.dto.AdventureStatusDto
 import com.now.naaga.data.remote.dto.CoordinateDto
 import com.now.naaga.data.remote.dto.FinishGameDto
 import com.now.naaga.data.remote.dto.HintDto
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
@@ -16,49 +16,49 @@ import retrofit2.http.Query
 
 interface AdventureService {
     @GET("/games")
-    fun getMyGames(): Call<List<AdventureDto>>
+    suspend fun getMyGames(): Response<List<AdventureDto>>
 
     @GET("/games/{gameId}")
-    fun getGame(
+    suspend fun getGame(
         @Path("gameId") gameId: Long,
-    ): Call<AdventureDto>
+    ): Response<AdventureDto>
 
     @GET("/games")
-    fun getGamesByStatus(
+    suspend fun getGamesByStatus(
         @Query("status") status: String,
-    ): Call<List<AdventureDto>>
+    ): Response<List<AdventureDto>>
 
     @POST("/games")
-    fun beginGame(
+    suspend fun beginGame(
         @Body coordinateDto: CoordinateDto,
-    ): Call<AdventureDto>
+    ): Response<AdventureDto>
 
     @PATCH("/games/{gameId}")
-    fun endGame(
+    suspend fun endGame(
         @Path("gameId") gameId: Long,
         @Body finishGameDto: FinishGameDto,
-    ): Call<AdventureStatusDto>
+    ): Response<AdventureStatusDto>
 
     @GET("/games/{gameId}/result")
-    fun getGameResult(
+    suspend fun getGameResult(
         @Path("gameId") gameId: Long,
-    ): Call<AdventureResultDto>
+    ): Response<AdventureResultDto>
 
     @GET("/games/results")
-    fun getMyGameResults(
+    suspend fun getMyGameResults(
         @Query("sort-by") sortBy: String,
         @Query("order") order: String,
-    ): Call<List<AdventureResultDto>>
+    ): Response<List<AdventureResultDto>>
 
     @GET("/games/{gameId}/hints/{hintId}")
-    fun getHint(
+    suspend fun getHint(
         @Path("gameId") gameId: Long,
         @Path("hintId") hingId: Long,
-    ): Call<HintDto>
+    ): Response<HintDto>
 
     @POST("/games/{gameId}/hints")
-    fun requestHint(
+    suspend fun requestHint(
         @Path("gameId") gameId: Long,
         @Body coordinateDto: CoordinateDto,
-    ): Call<HintDto>
+    ): Response<HintDto>
 }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAdventureRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAdventureRepository.kt
@@ -11,127 +11,61 @@ import com.now.domain.model.SortType
 import com.now.domain.repository.AdventureRepository
 import com.now.naaga.data.mapper.toDomain
 import com.now.naaga.data.mapper.toDto
-import com.now.naaga.data.remote.dto.AdventureDto
 import com.now.naaga.data.remote.dto.FinishGameDto
 import com.now.naaga.data.remote.retrofit.ServicePool
-import com.now.naaga.data.remote.retrofit.fetchResponse
+import com.now.naaga.util.getValueOrThrow
 
 class DefaultAdventureRepository : AdventureRepository {
-    override fun fetchMyAdventures(callback: (Result<List<Adventure>>) -> Unit) {
-        val call = ServicePool.adventureService.getMyGames()
-        call.fetchResponse(
-            onSuccess = { adventureDtos: List<AdventureDto> ->
-                callback(Result.success(adventureDtos.map { it.toDomain() }))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+    override suspend fun fetchMyAdventures(): List<Adventure> {
+        val response = ServicePool.adventureService.getMyGames().getValueOrThrow()
+        return response.map { it.toDomain() }
     }
 
-    override fun fetchAdventure(adventureId: Long, callback: (Result<Adventure>) -> Unit) {
-        val call = ServicePool.adventureService.getGame(adventureId)
-        call.fetchResponse(
-            onSuccess = { adventureDto ->
-                callback(Result.success(adventureDto.toDomain()))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+    override suspend fun fetchAdventure(adventureId: Long): Adventure {
+        val response = ServicePool.adventureService.getGame(adventureId).getValueOrThrow()
+        return response.toDomain()
     }
 
-    override fun fetchAdventureByStatus(status: AdventureStatus, callback: (Result<List<Adventure>>) -> Unit) {
-        val call = ServicePool.adventureService.getGamesByStatus(status.name)
-        call.fetchResponse(
-            onSuccess = { adventureDtos: List<AdventureDto> ->
-                callback(Result.success(adventureDtos.map { it.toDomain() }))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+    override suspend fun fetchAdventureByStatus(status: AdventureStatus): List<Adventure> {
+        val response = ServicePool.adventureService.getGamesByStatus(status.name).getValueOrThrow()
+        return response.map { it.toDomain() }
     }
 
-    override fun beginAdventure(coordinate: Coordinate, callback: (Result<Adventure>) -> Unit) {
-        val call = ServicePool.adventureService.beginGame(coordinate.toDto())
-        call.fetchResponse(
-            onSuccess = { adventureDto ->
-                callback(Result.success(adventureDto.toDomain()))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+    override suspend fun beginAdventure(coordinate: Coordinate): Adventure {
+        val response = ServicePool.adventureService.beginGame(coordinate.toDto()).getValueOrThrow()
+        return response.toDomain()
     }
 
-    override fun endGame(
+    override suspend fun endGame(
         adventureId: Long,
         endType: AdventureEndType,
         coordinate: Coordinate,
-        callback: (Result<AdventureStatus>) -> Unit,
-    ) {
+    ): AdventureStatus {
         val finishGameDto = FinishGameDto(endType.name, coordinate.toDto())
-        val call = ServicePool.adventureService.endGame(adventureId, finishGameDto)
-        call.fetchResponse(
-            onSuccess = { adventureStatusDto ->
-                callback(Result.success(AdventureStatus.getStatus(adventureStatusDto.gameStatus)))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+        val response = ServicePool.adventureService.endGame(adventureId, finishGameDto).getValueOrThrow()
+        return AdventureStatus.getStatus(response.gameStatus)
     }
 
-    override fun fetchAdventureResult(adventureId: Long, callback: (Result<AdventureResult>) -> Unit) {
-        val call = ServicePool.adventureService.getGameResult(adventureId)
-        call.fetchResponse(
-            onSuccess = { adventureResultDto ->
-                callback(Result.success(adventureResultDto.toDomain()))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+    override suspend fun fetchAdventureResult(adventureId: Long): AdventureResult {
+        val response = ServicePool.adventureService.getGameResult(adventureId).getValueOrThrow()
+        return response.toDomain()
     }
 
-    override fun fetchMyAdventureResults(
+    override suspend fun fetchMyAdventureResults(
         sortBy: SortType,
         order: OrderType,
-        callback: (Result<List<AdventureResult>>) -> Unit,
-    ) {
-        val call = ServicePool.adventureService.getMyGameResults(sortBy.name, order.name)
-        call.fetchResponse(
-            onSuccess = { adventureResultDtos ->
-                callback(Result.success(adventureResultDtos.map { it.toDomain() }))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+    ): List<AdventureResult> {
+        val response = ServicePool.adventureService.getMyGameResults(sortBy.name, order.name).getValueOrThrow()
+        return response.map { it.toDomain() }
     }
 
-    override fun fetchHint(adventureId: Long, hintId: Long, callback: (Result<Hint>) -> Unit) {
-        val call = ServicePool.adventureService.getHint(adventureId, hintId)
-        call.fetchResponse(
-            onSuccess = { hintDto ->
-                callback(Result.success(hintDto.toDomain()))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+    override suspend fun fetchHint(adventureId: Long, hintId: Long): Hint {
+        val response = ServicePool.adventureService.getHint(adventureId, hintId).getValueOrThrow()
+        return response.toDomain()
     }
 
-    override fun makeHint(adventureId: Long, coordinate: Coordinate, callback: (Result<Hint>) -> Unit) {
-        val call = ServicePool.adventureService.requestHint(adventureId, coordinate.toDto())
-        call.fetchResponse(
-            onSuccess = { hintDto ->
-                callback(Result.success(hintDto.toDomain()))
-            },
-            onFailure = {
-                callback(Result.failure(it))
-            },
-        )
+    override suspend fun makeHint(adventureId: Long, coordinate: Coordinate): Hint {
+        val response = ServicePool.adventureService.requestHint(adventureId, coordinate.toDto()).getValueOrThrow()
+        return response.toDomain()
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/adventureresult/AdventureResultViewModel.kt
@@ -29,14 +29,15 @@ class AdventureResultViewModel(
     val throwable: LiveData<DataThrowable> = _throwable
 
     fun fetchGameResult(adventureId: Long) {
-        adventureRepository.fetchAdventureResult(
-            adventureId,
-            callback = { result ->
-                result
-                    .onSuccess { adventureResult -> _adventureResult.value = adventureResult }
-                    .onFailure { setErrorMessage(it as DataThrowable) }
-            },
-        )
+        viewModelScope.launch {
+            runCatching {
+                adventureRepository.fetchAdventureResult(adventureId)
+            }.onSuccess { adventureResult ->
+                _adventureResult.value = adventureResult
+            }.onFailure {
+                setErrorMessage(it as DataThrowable)
+            }
+        }
     }
 
     fun fetchMyRank() {
@@ -53,7 +54,10 @@ class AdventureResultViewModel(
 
     private fun setErrorMessage(throwable: DataThrowable) {
         when (throwable) {
-            is GameThrowable -> { _throwable.value = throwable }
+            is GameThrowable -> {
+                _throwable.value = throwable
+            }
+
             else -> {}
         }
     }

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureViewModel.kt
@@ -58,9 +58,9 @@ class OnAdventureViewModel(private val adventureRepository: AdventureRepository)
         viewModelScope.launch {
             runCatching {
                 adventureRepository.endGame(
-                    adventureId = adventure.value?.id ?: throw IllegalStateException("[ERROR] adventure가 없습니다."),
+                    adventureId = adventure.value?.id ?: throw IllegalStateException(ADVENTURE_IS_NULL),
                     endType = AdventureEndType.GIVE_UP,
-                    coordinate = myCoordinate.value ?: throw IllegalStateException("[ERROR] myCoordinate가 없습니다."),
+                    coordinate = myCoordinate.value ?: throw IllegalStateException(MY_COORDINATE_IS_NULL),
                 )
             }.onSuccess { status: AdventureStatus ->
                 _adventure.value = adventure.value?.copy(adventureStatus = status)
@@ -78,8 +78,8 @@ class OnAdventureViewModel(private val adventureRepository: AdventureRepository)
         viewModelScope.launch {
             runCatching {
                 adventureRepository.makeHint(
-                    adventureId = adventure.value?.id ?: throw IllegalStateException("[ERROR] adventure가 없습니다."),
-                    coordinate = myCoordinate.value ?: throw IllegalStateException("[ERROR] myCoordinate가 없습니다."),
+                    adventureId = adventure.value?.id ?: throw IllegalStateException(ADVENTURE_IS_NULL),
+                    coordinate = myCoordinate.value ?: throw IllegalStateException(MY_COORDINATE_IS_NULL),
                 )
             }.onSuccess { hint: Hint ->
                 _adventure.value = adventure.value?.copy(hints = ((adventure.value?.hints ?: listOf()) + hint))
@@ -103,9 +103,9 @@ class OnAdventureViewModel(private val adventureRepository: AdventureRepository)
         viewModelScope.launch {
             runCatching {
                 adventureRepository.endGame(
-                    adventureId = adventure.value?.id ?: throw IllegalStateException("[ERROR] adventure가 없습니다."),
+                    adventureId = adventure.value?.id ?: throw IllegalStateException(ADVENTURE_IS_NULL),
                     endType = AdventureEndType.ARRIVED,
-                    coordinate = myCoordinate.value ?: throw IllegalStateException("[ERROR] myCoordinate가 없습니다."),
+                    coordinate = myCoordinate.value ?: throw IllegalStateException(MY_COORDINATE_IS_NULL),
                 )
             }.onSuccess {
                 _adventure.value = adventure.value?.copy(adventureStatus = it)
@@ -135,6 +135,9 @@ class OnAdventureViewModel(private val adventureRepository: AdventureRepository)
         const val NO_DESTINATION = 406
         const val NOT_ARRIVED = 415
         const val TRY_COUNT_OVER = 416
+        private const val ERROR_PREFIX = "[ERROR] OnAdventureViewModel:"
+        private const val ADVENTURE_IS_NULL = "$ERROR_PREFIX adventure가 널입니다."
+        private const val MY_COORDINATE_IS_NULL = "$ERROR_PREFIX myCoordinate가 널입니다."
         val Factory = ViewModelFactory(DefaultAdventureRepository())
 
         class ViewModelFactory(private val adventureRepository: AdventureRepository) : ViewModelProvider.Factory {

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashViewModel.kt
@@ -4,10 +4,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.now.domain.model.Adventure
 import com.now.domain.model.AdventureStatus
 import com.now.domain.repository.AdventureRepository
 import com.now.naaga.data.repository.DefaultAdventureRepository
+import kotlinx.coroutines.launch
 
 class SplashViewModel(private val adventureRepository: AdventureRepository) : ViewModel() {
     private val _adventure = MutableLiveData<Adventure>()
@@ -17,10 +19,14 @@ class SplashViewModel(private val adventureRepository: AdventureRepository) : Vi
     val adventureStatus: LiveData<AdventureStatus> = _adventureStatus
 
     fun fetchInProgressAdventure() {
-        adventureRepository.fetchAdventureByStatus(AdventureStatus.IN_PROGRESS) { result: Result<List<Adventure>> ->
-            result
-                .onSuccess { fetchAdventure(it) }
-                .onFailure { _adventureStatus.value = AdventureStatus.NONE }
+        viewModelScope.launch {
+            runCatching {
+                adventureRepository.fetchAdventureByStatus(AdventureStatus.IN_PROGRESS)
+            }.onSuccess {
+                fetchAdventure(it)
+            }.onFailure {
+                _adventureStatus.value = AdventureStatus.NONE
+            }
         }
     }
 

--- a/android/domain/src/main/java/com/now/domain/repository/AdventureRepository.kt
+++ b/android/domain/src/main/java/com/now/domain/repository/AdventureRepository.kt
@@ -10,38 +10,31 @@ import com.now.domain.model.OrderType
 import com.now.domain.model.SortType
 
 interface AdventureRepository {
-    fun fetchMyAdventures(callback: (Result<List<Adventure>>) -> Unit)
+    suspend fun fetchMyAdventures(): List<Adventure>
+    suspend fun fetchAdventure(adventureId: Long): Adventure
+    suspend fun fetchAdventureByStatus(status: AdventureStatus): List<Adventure>
+    suspend fun beginAdventure(coordinate: Coordinate): Adventure
 
-    fun fetchAdventure(adventureId: Long, callback: (Result<Adventure>) -> Unit)
-
-    fun fetchAdventureByStatus(status: AdventureStatus, callback: (Result<List<Adventure>>) -> Unit)
-
-    fun beginAdventure(coordinate: Coordinate, callback: (Result<Adventure>) -> Unit)
-
-    fun endGame(
+    suspend fun endGame(
         adventureId: Long,
         endType: AdventureEndType,
         coordinate: Coordinate,
-        callback: (Result<AdventureStatus>) -> Unit,
-    )
+    ): AdventureStatus
 
-    fun fetchAdventureResult(adventureId: Long, callback: (Result<AdventureResult>) -> Unit)
+    suspend fun fetchAdventureResult(adventureId: Long): AdventureResult
 
-    fun fetchMyAdventureResults(
+    suspend fun fetchMyAdventureResults(
         sortBy: SortType,
         order: OrderType,
-        callback: (Result<List<AdventureResult>>) -> Unit,
-    )
+    ): List<AdventureResult>
 
-    fun fetchHint(
+    suspend fun fetchHint(
         adventureId: Long,
         hintId: Long,
-        callback: (Result<Hint>) -> Unit,
-    )
+    ): Hint
 
-    fun makeHint(
+    suspend fun makeHint(
         adventureId: Long,
         coordinate: Coordinate,
-        callback: (Result<Hint>) -> Unit,
-    )
+    ): Hint
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed #314 

## 🛠️ 작업 내용
- [x] AdventureService 변경
- [x] AdventureRepository 변경
- [x] OnAdventureViewModel 변경
- [x] AdventureHistoryViewModel 변경
- [x] AdventureResultViewModel 변경
- [x] BeginAdventure 변경
- [x] SplashViewModel 변경

## ⏳ 작업 시간
추정 시간: 1h
실제 시간:  1h
