### PR TITLE
fix: History 뷰의 리사이클러뷰 image 오류 문제 해결

### DIFF
--- a/android/app/src/main/res/layout/activity_adventure_history.xml
+++ b/android/app/src/main/res/layout/activity_adventure_history.xml
@@ -13,13 +13,13 @@
             android:id="@+id/iv_adventureHistory_back"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="24dp"
-            android:layout_marginTop="24dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="16dp"
             android:paddingHorizontal="16dp"
             android:paddingVertical="12dp"
+            android:src="@drawable/ic_arrow"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            android:src="@drawable/ic_arrow" />
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
             android:id="@+id/tv_adventureHistory_title"

--- a/android/app/src/main/res/layout/item_history.xml
+++ b/android/app/src/main/res/layout/item_history.xml
@@ -28,7 +28,6 @@
             android:layout_marginTop="12dp"
             android:layout_marginEnd="12dp"
             android:scaleType="centerCrop"
-            android:src="@{adventureResult.destination.image}"
             android:background="@drawable/rect_radius_small"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #316 

## 🛠️ 작업 내용
- [X] History 뷰의 리사이클러뷰 image 로딩 오류 문제 해결

## 🎯 리뷰 포인트
이미지 설정 코드가 중복으로 들어가 있어서 해당 버그가 발생한 것 입니다. 현재 중복 로직 삭제했고 잘 돌아갑니다

## ⏳ 작업 시간
추정 시간:  10m 
실제 시간:  10m 
