### PR TITLE
refactor: Login 뷰에서 진행하는 네트워크 작업 코루틴으로 변경

### DIFF
--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
@@ -2,13 +2,13 @@ package com.now.naaga.data.remote.retrofit.service
 
 import com.now.naaga.data.remote.dto.NaagaAuthDto
 import com.now.naaga.data.remote.dto.PlatformAuthDto
-import retrofit2.Call
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AuthService {
     @POST("/auth")
-    fun requestAuth(
+    suspend fun requestAuth(
         @Body platformAuthDto: PlatformAuthDto,
-    ): Call<NaagaAuthDto>
+    ): Response<NaagaAuthDto>
 }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -4,9 +4,7 @@ import com.now.domain.model.PlatformAuth
 import com.now.domain.repository.AuthRepository
 import com.now.naaga.data.local.AuthDataSource
 import com.now.naaga.data.mapper.toDto
-import com.now.naaga.data.remote.retrofit.ServicePool
 import com.now.naaga.data.remote.retrofit.ServicePool.authService
-import com.now.naaga.data.remote.retrofit.fetchResponse
 import com.now.naaga.util.getValueOrThrow
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -5,21 +5,28 @@ import com.now.domain.repository.AuthRepository
 import com.now.naaga.data.local.AuthDataSource
 import com.now.naaga.data.mapper.toDto
 import com.now.naaga.data.remote.retrofit.ServicePool
+import com.now.naaga.data.remote.retrofit.ServicePool.authService
 import com.now.naaga.data.remote.retrofit.fetchResponse
+import com.now.naaga.util.getValueOrThrow
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
-class DefaultAuthRepository(private val authDataSource: AuthDataSource) : AuthRepository {
-    override fun getToken(
-        platformAuth: PlatformAuth,
-        callback: (Result<Boolean>) -> Unit,
-    ) {
-        val call = ServicePool.authService.requestAuth(platformAuth.toDto())
-        call.fetchResponse(
-            onSuccess = { naagaAuthDto ->
+class DefaultAuthRepository(
+    private val authDataSource: AuthDataSource,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+) : AuthRepository {
+
+    override suspend fun getToken(platformAuth: PlatformAuth): Boolean {
+        return withContext(dispatcher) {
+            val response = authService.requestAuth(platformAuth.toDto())
+            runCatching {
+                val naagaAuthDto = response.getValueOrThrow()
                 authDataSource.setAccessToken(naagaAuthDto.accessToken)
                 authDataSource.setRefreshToken(naagaAuthDto.refreshToken)
-                callback(Result.success(true))
-            },
-            onFailure = { callback(Result.failure(it)) },
-        )
+                return@withContext true
+            }
+            return@withContext false
+        }
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
@@ -17,6 +17,7 @@ import com.now.naaga.data.repository.DefaultAuthRepository
 import com.now.naaga.databinding.ActivityLoginBinding
 import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import com.now.naaga.util.loginWithKakao
+import kotlinx.coroutines.Dispatchers
 
 class LoginActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalyticsDelegate() {
     private lateinit var binding: ActivityLoginBinding
@@ -35,7 +36,7 @@ class LoginActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytics
     }
 
     private fun initViewModel() {
-        val factory = LoginViewModelFactory(DefaultAuthRepository(NaagaApplication.authDataSource))
+        val factory = LoginViewModelFactory(DefaultAuthRepository(NaagaApplication.authDataSource, Dispatchers.IO))
         viewModel = ViewModelProvider(this, factory)[LoginViewModel::class.java]
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
@@ -17,7 +17,6 @@ import com.now.naaga.data.repository.DefaultAuthRepository
 import com.now.naaga.databinding.ActivityLoginBinding
 import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import com.now.naaga.util.loginWithKakao
-import kotlinx.coroutines.Dispatchers
 
 class LoginActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalyticsDelegate() {
     private lateinit var binding: ActivityLoginBinding
@@ -36,7 +35,7 @@ class LoginActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytics
     }
 
     private fun initViewModel() {
-        val factory = LoginViewModelFactory(DefaultAuthRepository(NaagaApplication.authDataSource, Dispatchers.IO))
+        val factory = LoginViewModelFactory(DefaultAuthRepository(NaagaApplication.authDataSource))
         viewModel = ViewModelProvider(this, factory)[LoginViewModel::class.java]
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/login/LoginViewModel.kt
@@ -1,12 +1,15 @@
 package com.now.naaga.presentation.login
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.now.domain.model.AuthPlatformType
 import com.now.domain.model.PlatformAuth
 import com.now.domain.repository.AuthRepository
 import com.now.naaga.data.throwable.DataThrowable
+import kotlinx.coroutines.launch
 
 class LoginViewModel(
     private val authRepository: AuthRepository,
@@ -18,10 +21,15 @@ class LoginViewModel(
     val throwable: LiveData<DataThrowable> = _throwable
 
     fun signIn(token: String, platformType: AuthPlatformType) {
-        authRepository.getToken(PlatformAuth(token, platformType)) { result ->
-            result
-                .onSuccess { _isLoginSucceed.value = it }
-                .onFailure { _throwable.value = it as DataThrowable }
+        viewModelScope.launch {
+            runCatching {
+                authRepository.getToken(PlatformAuth(token, platformType))
+            }.onSuccess { status ->
+                _isLoginSucceed.value = status
+            }.onFailure {
+                Log.d("test", "${it.message} , ${it}")
+                _throwable.value = it as DataThrowable
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/login/LoginViewModel.kt
@@ -1,6 +1,5 @@
 package com.now.naaga.presentation.login
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -27,7 +26,6 @@ class LoginViewModel(
             }.onSuccess { status ->
                 _isLoginSucceed.value = status
             }.onFailure {
-                Log.d("test", "${it.message} , ${it}")
                 _throwable.value = it as DataThrowable
             }
         }

--- a/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
+++ b/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
@@ -3,8 +3,7 @@ package com.now.domain.repository
 import com.now.domain.model.PlatformAuth
 
 interface AuthRepository {
-    fun getToken(
+    suspend fun getToken(
         platformAuth: PlatformAuth,
-        callback: (Result<Boolean>) -> Unit,
-    )
+    ): Boolean
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #326 

## 🛠️ 작업 내용
- [X] AuthRepository, AuthService 변경

## 🎯 리뷰 포인트
AuthRepository 내에서 서버 통신 시 받아온 토큰 값을 SharedPreference에 저장해야 했습니다. 따라서 레포지터리 내의 코루틴 사용이 필요해져 해당 AuthRepository 생성 시 Dispatcher을 클래스의 인자로 넘겨주도록 수정하였습니다. 해당 로직이 괜찮은 지 확인 부탁드립니다!

## ⏳ 작업 시간
추정 시간:  1h 
실제 시간:  1h
