### PR TITLE
feat: 회원 탈퇴 기능 구현

### DIFF
--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
@@ -13,6 +13,6 @@ interface AuthService {
         @Body platformAuthDto: PlatformAuthDto,
     ): Response<NaagaAuthDto>
 
-    @DELETE("/auth/member")
+    @DELETE("/auth/unlink")
     suspend fun withdrawalMember()
 }

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
@@ -4,6 +4,7 @@ import com.now.naaga.data.remote.dto.NaagaAuthDto
 import com.now.naaga.data.remote.dto.PlatformAuthDto
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.POST
 
 interface AuthService {
@@ -11,4 +12,7 @@ interface AuthService {
     suspend fun requestAuth(
         @Body platformAuthDto: PlatformAuthDto,
     ): Response<NaagaAuthDto>
+
+    @DELETE("/auth/member")
+    suspend fun withdrawalMember()
 }

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
@@ -14,5 +14,5 @@ interface AuthService {
     ): Response<NaagaAuthDto>
 
     @DELETE("/auth/unlink")
-    suspend fun withdrawalMember(): Response<Unit>?
+    suspend fun withdrawalMember(): Response<Unit>
 }

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
@@ -14,5 +14,5 @@ interface AuthService {
     ): Response<NaagaAuthDto>
 
     @DELETE("/auth/unlink")
-    suspend fun withdrawalMember()
+    suspend fun withdrawalMember(): Response<Unit>?
 }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -1,12 +1,10 @@
 package com.now.naaga.data.repository
 
-import android.util.Log
 import com.now.domain.model.PlatformAuth
 import com.now.domain.repository.AuthRepository
 import com.now.naaga.data.local.AuthDataSource
 import com.now.naaga.data.mapper.toDto
 import com.now.naaga.data.remote.retrofit.ServicePool.authService
-import com.now.naaga.util.KAKAO_LOGIN_LOG_TAG
 import com.now.naaga.util.getValueOrThrow
 import com.now.naaga.util.unlinkWithKakao
 import kotlinx.coroutines.CoroutineDispatcher
@@ -15,7 +13,7 @@ import kotlinx.coroutines.withContext
 
 class DefaultAuthRepository(
     private val authDataSource: AuthDataSource,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AuthRepository {
 
     override suspend fun getToken(platformAuth: PlatformAuth): Boolean {
@@ -31,17 +29,8 @@ class DefaultAuthRepository(
         }
     }
 
-    override suspend fun withdrawalMember(): Boolean {
-        return withContext(dispatcher) {
-            runCatching {
-                authService.withdrawalMember()
-                return@withContext true
-            }.onSuccess {
-                unlinkWithKakao()
-            }.onFailure {
-                Log.d(KAKAO_LOGIN_LOG_TAG, "${it.message}, $it")
-            }
-            return@withContext false
-        }
+    override suspend fun withdrawalMember() {
+        authService.withdrawalMember()
+        unlinkWithKakao()
     }
 }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -6,6 +6,7 @@ import com.now.domain.repository.AuthRepository
 import com.now.naaga.data.local.AuthDataSource
 import com.now.naaga.data.mapper.toDto
 import com.now.naaga.data.remote.retrofit.ServicePool.authService
+import com.now.naaga.util.KAKAO_LOGIN_LOG_TAG
 import com.now.naaga.util.getValueOrThrow
 import com.now.naaga.util.unlinkWithKakao
 import kotlinx.coroutines.CoroutineDispatcher
@@ -34,15 +35,12 @@ class DefaultAuthRepository(
         return withContext(dispatcher) {
             runCatching {
                 authService.withdrawalMember()
-                Log.d("test", "회원탈퇴 성공")
                 return@withContext true
             }.onSuccess {
                 unlinkWithKakao()
-                Log.d("test", "카카오 회원탈퇴 성공")
             }.onFailure {
-                Log.d("test", "${it.message}, ${it}")
+                Log.d(KAKAO_LOGIN_LOG_TAG, "${it.message}, ${it}")
             }
-            Log.d("test", "회원탈퇴 실패")
             return@withContext false
         }
     }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -39,7 +39,7 @@ class DefaultAuthRepository(
             }.onSuccess {
                 unlinkWithKakao()
             }.onFailure {
-                Log.d(KAKAO_LOGIN_LOG_TAG, "${it.message}, ${it}")
+                Log.d(KAKAO_LOGIN_LOG_TAG, "${it.message}, $it")
             }
             return@withContext false
         }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -1,11 +1,13 @@
 package com.now.naaga.data.repository
 
+import android.util.Log
 import com.now.domain.model.PlatformAuth
 import com.now.domain.repository.AuthRepository
 import com.now.naaga.data.local.AuthDataSource
 import com.now.naaga.data.mapper.toDto
 import com.now.naaga.data.remote.retrofit.ServicePool.authService
 import com.now.naaga.util.getValueOrThrow
+import com.now.naaga.util.unlinkWithKakao
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,6 +26,23 @@ class DefaultAuthRepository(
                 authDataSource.setRefreshToken(naagaAuthDto.refreshToken)
                 return@withContext true
             }
+            return@withContext false
+        }
+    }
+
+    override suspend fun withdrawalMember(): Boolean {
+        return withContext(dispatcher) {
+            runCatching {
+                authService.withdrawalMember()
+                Log.d("test", "회원탈퇴 성공")
+                return@withContext true
+            }.onSuccess {
+                unlinkWithKakao()
+                Log.d("test", "카카오 회원탈퇴 성공")
+            }.onFailure {
+                Log.d("test", "${it.message}, ${it}")
+            }
+            Log.d("test", "회원탈퇴 실패")
             return@withContext false
         }
     }

--- a/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/login/LoginActivity.kt
@@ -2,6 +2,8 @@ package com.now.naaga.presentation.login
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.FLAG_ACTIVITY_CLEAR_TASK
+import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
@@ -74,6 +76,13 @@ class LoginActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytics
     companion object {
         fun getIntent(context: Context): Intent {
             return Intent(context, LoginActivity::class.java)
+        }
+
+        fun getIntentWithTop(context: Context): Intent {
+            return Intent(context, LoginActivity::class.java).apply {
+                addFlags(FLAG_ACTIVITY_NEW_TASK)
+                addFlags(FLAG_ACTIVITY_CLEAR_TASK)
+            }
         }
     }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
@@ -63,13 +63,12 @@ class SettingActivity : AppCompatActivity() {
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 
-
     companion object {
         private const val WITHDRAWAL_SUCCESS_MESSAGE = "성공적으로 회원 탈퇴 되었습니다."
         private const val WRONG_ERROR_MESSAGE = "인증 정보가 잘 못 되었어요!"
         private const val EXPIRATION_ERROR_MESSAGE = "인증 정보가 만료 되었어요!"
 
-    fun getIntent(context: Context): Intent {
+        fun getIntent(context: Context): Intent {
             return Intent(context, SettingActivity::class.java)
         }
     }

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
@@ -48,8 +48,8 @@ class SettingActivity : AppCompatActivity() {
 
         viewModel.errorMessage.observe(this) { error: DataThrowable ->
             when (error.code) {
-                101 -> shortToast(WRONG_ERROR_MESSAGE)
-                102 -> shortToast(EXPIRATION_ERROR_MESSAGE)
+                WRONG_AUTH_ERROR_CODE -> shortToast(WRONG_ERROR_MESSAGE)
+                EXPIRATION_AUTH_ERROR_CODE -> shortToast(EXPIRATION_ERROR_MESSAGE)
             }
         }
     }
@@ -64,6 +64,8 @@ class SettingActivity : AppCompatActivity() {
     }
 
     companion object {
+        private const val WRONG_AUTH_ERROR_CODE = 101
+        private const val EXPIRATION_AUTH_ERROR_CODE = 102
         private const val WITHDRAWAL_SUCCESS_MESSAGE = "성공적으로 회원 탈퇴 되었습니다."
         private const val WRONG_ERROR_MESSAGE = "인증 정보가 잘 못 되었어요!"
         private const val EXPIRATION_ERROR_MESSAGE = "인증 정보가 만료 되었어요!"

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
@@ -3,9 +3,12 @@ package com.now.naaga.presentation.setting
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
+import com.now.naaga.data.throwable.DataThrowable
 import com.now.naaga.databinding.ActivitySettingBinding
+import com.now.naaga.presentation.login.LoginActivity
 
 class SettingActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySettingBinding
@@ -17,6 +20,7 @@ class SettingActivity : AppCompatActivity() {
         setContentView(binding.root)
         initViewModel()
         setClickListeners()
+        subscribe()
     }
 
     private fun initViewModel() {
@@ -28,10 +32,44 @@ class SettingActivity : AppCompatActivity() {
         binding.ivSettingBack.setOnClickListener {
             finish()
         }
+
+        binding.tvSettingUnlink.setOnClickListener {
+            viewModel.withdrawalMember()
+        }
     }
 
+    private fun subscribe() {
+        viewModel.withdrawalStatue.observe(this) { status ->
+            if (status == true) {
+                shortToast(WITHDRAWAL_SUCCESS_MESSAGE)
+                navigateLogin()
+            }
+        }
+
+        viewModel.errorMessage.observe(this) { error: DataThrowable ->
+            when (error.code) {
+                101 -> shortToast(WRONG_ERROR_MESSAGE)
+                102 -> shortToast(EXPIRATION_ERROR_MESSAGE)
+            }
+        }
+    }
+
+    private fun navigateLogin() {
+        startActivity(LoginActivity.getIntent(this))
+        finish()
+    }
+
+    private fun shortToast(message: String) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+    }
+
+
     companion object {
-        fun getIntent(context: Context): Intent {
+        private const val WITHDRAWAL_SUCCESS_MESSAGE = "성공적으로 회원 탈퇴 되었습니다."
+        private const val WRONG_ERROR_MESSAGE = "인증 정보가 잘 못 되었어요!"
+        private const val EXPIRATION_ERROR_MESSAGE = "인증 정보가 만료 되었어요!"
+
+    fun getIntent(context: Context): Intent {
             return Intent(context, SettingActivity::class.java)
         }
     }

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
@@ -39,7 +39,7 @@ class SettingActivity : AppCompatActivity() {
     }
 
     private fun subscribe() {
-        viewModel.withdrawalStatue.observe(this) { status ->
+        viewModel.withdrawalStatus.observe(this) { status ->
             if (status == true) {
                 shortToast(WITHDRAWAL_SUCCESS_MESSAGE)
                 navigateLogin()

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
@@ -6,9 +6,11 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
+import com.now.naaga.R
 import com.now.naaga.data.throwable.DataThrowable
 import com.now.naaga.databinding.ActivitySettingBinding
 import com.now.naaga.presentation.login.LoginActivity
+import com.now.naaga.presentation.onadventure.NaagaAlertDialog
 
 class SettingActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySettingBinding
@@ -34,22 +36,22 @@ class SettingActivity : AppCompatActivity() {
         }
 
         binding.tvSettingUnlink.setOnClickListener {
-            viewModel.withdrawalMember()
+            showWithdrawalDialog()
         }
     }
 
     private fun subscribe() {
         viewModel.withdrawalStatus.observe(this) { status ->
             if (status == true) {
-                shortToast(WITHDRAWAL_SUCCESS_MESSAGE)
+                shortToast(getString(R.string.setting_withdrawal_success_message))
                 navigateLogin()
             }
         }
 
         viewModel.errorMessage.observe(this) { error: DataThrowable ->
             when (error.code) {
-                WRONG_AUTH_ERROR_CODE -> shortToast(WRONG_ERROR_MESSAGE)
-                EXPIRATION_AUTH_ERROR_CODE -> shortToast(EXPIRATION_ERROR_MESSAGE)
+                WRONG_AUTH_ERROR_CODE -> shortToast(getString(R.string.setting_wrong_error_message))
+                EXPIRATION_AUTH_ERROR_CODE -> shortToast(getString(R.string.setting_expiration_error_message))
             }
         }
     }
@@ -63,12 +65,22 @@ class SettingActivity : AppCompatActivity() {
         Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
     }
 
+    private fun showWithdrawalDialog() {
+        NaagaAlertDialog.Builder().build(
+            title = getString(R.string.withdrawal_dialog_title),
+            description = getString(R.string.withdrawal_dialog_description),
+            positiveText = getString(R.string.withdrawal_dialog_negative),
+            negativeText = getString(R.string.withdrawal_dialog_positive),
+            positiveAction = { },
+            negativeAction = { viewModel.withdrawalMember() },
+        ).show(supportFragmentManager, WITHDRAWAL)
+    }
+
     companion object {
+        private const val WITHDRAWAL = "WITHDRAWAL"
+
         private const val WRONG_AUTH_ERROR_CODE = 101
         private const val EXPIRATION_AUTH_ERROR_CODE = 102
-        private const val WITHDRAWAL_SUCCESS_MESSAGE = "성공적으로 회원 탈퇴 되었습니다."
-        private const val WRONG_ERROR_MESSAGE = "인증 정보가 잘 못 되었어요!"
-        private const val EXPIRATION_ERROR_MESSAGE = "인증 정보가 만료 되었어요!"
 
         fun getIntent(context: Context): Intent {
             return Intent(context, SettingActivity::class.java)

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingActivity.kt
@@ -55,7 +55,7 @@ class SettingActivity : AppCompatActivity() {
     }
 
     private fun navigateLogin() {
-        startActivity(LoginActivity.getIntent(this))
+        startActivity(LoginActivity.getIntentWithTop(this))
         finish()
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingViewModel.kt
@@ -1,1 +1,40 @@
-package com.now.naaga.presentation.settingimport androidx.lifecycle.LiveDataimport androidx.lifecycle.MutableLiveDataimport androidx.lifecycle.ViewModelimport androidx.lifecycle.ViewModelProviderimport androidx.lifecycle.viewModelScopeimport com.now.domain.repository.AuthRepositoryimport com.now.naaga.NaagaApplication.DependencyContainer.authDataSourceimport com.now.naaga.data.repository.DefaultAuthRepositoryimport com.now.naaga.data.throwable.DataThrowableimport kotlinx.coroutines.launchclass SettingViewModel(private val authRepository: AuthRepository) : ViewModel() {    private val _withdrawalStatue = MutableLiveData<Boolean>()    val withdrawalStatue: LiveData<Boolean> = _withdrawalStatue    private val _errorMessage = MutableLiveData<DataThrowable>()    val errorMessage: LiveData<DataThrowable> = _errorMessage    fun withdrawalMember() {        viewModelScope.launch {            runCatching { authRepository.withdrawalMember() }                .onSuccess { _withdrawalStatue.value = it }                .onFailure { _errorMessage.value = it as DataThrowable }        }    }    companion object {        val Factory = SettingFactory(DefaultAuthRepository(authDataSource))        class SettingFactory(private val authRepository: AuthRepository) :            ViewModelProvider.Factory {            override fun <T : ViewModel> create(modelClass: Class<T>): T {                return SettingViewModel(authRepository) as T            }        }    }}
+package com.now.naaga.presentation.setting
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.now.domain.repository.AuthRepository
+import com.now.naaga.NaagaApplication.DependencyContainer.authDataSource
+import com.now.naaga.data.repository.DefaultAuthRepository
+import com.now.naaga.data.throwable.DataThrowable
+import kotlinx.coroutines.launch
+
+class SettingViewModel(private val authRepository: AuthRepository) : ViewModel() {
+
+    private val _withdrawalStatus = MutableLiveData<Boolean>()
+    val withdrawalStatus: LiveData<Boolean> = _withdrawalStatus
+
+    private val _errorMessage = MutableLiveData<DataThrowable>()
+    val errorMessage: LiveData<DataThrowable> = _errorMessage
+
+    fun withdrawalMember() {
+        viewModelScope.launch {
+            runCatching { authRepository.withdrawalMember() }
+                .onSuccess { _withdrawalStatus.value = it }
+                .onFailure { _errorMessage.value = it as DataThrowable }
+        }
+    }
+
+    companion object {
+        val Factory = SettingFactory(DefaultAuthRepository(authDataSource))
+
+        class SettingFactory(private val authRepository: AuthRepository) :
+            ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return SettingViewModel(authRepository) as T
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingViewModel.kt
@@ -22,7 +22,7 @@ class SettingViewModel(private val authRepository: AuthRepository) : ViewModel()
     fun withdrawalMember() {
         viewModelScope.launch {
             runCatching { authRepository.withdrawalMember() }
-                .onSuccess { _withdrawalStatus.value = it }
+                .onSuccess { _withdrawalStatus.value = true }
                 .onFailure { _errorMessage.value = it as DataThrowable }
         }
     }

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingViewModel.kt
@@ -1,12 +1,32 @@
 package com.now.naaga.presentation.setting
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import com.now.domain.repository.AuthRepository
 import com.now.naaga.NaagaApplication.DependencyContainer.authDataSource
 import com.now.naaga.data.repository.DefaultAuthRepository
+import com.now.naaga.data.throwable.DataThrowable
+import kotlinx.coroutines.launch
 
 class SettingViewModel(private val authRepository: AuthRepository) : ViewModel() {
+
+    private val _withdrawalStatue = MutableLiveData<Boolean>()
+    val withdrawalStatue: LiveData<Boolean> = _withdrawalStatue
+
+    private val _errorMessage = MutableLiveData<DataThrowable>()
+    val errorMessage: LiveData<DataThrowable> = _errorMessage
+
+    fun withdrawalMember() {
+        viewModelScope.launch {
+            runCatching { authRepository.withdrawalMember() }
+                .onSuccess { _withdrawalStatue.value = it }
+                .onFailure { _errorMessage.value = it as DataThrowable }
+
+        }
+    }
 
     companion object {
         val Factory = SettingFactory(DefaultAuthRepository(authDataSource))

--- a/android/app/src/main/java/com/now/naaga/presentation/setting/SettingViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/setting/SettingViewModel.kt
@@ -1,41 +1,1 @@
-package com.now.naaga.presentation.setting
-
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
-import com.now.domain.repository.AuthRepository
-import com.now.naaga.NaagaApplication.DependencyContainer.authDataSource
-import com.now.naaga.data.repository.DefaultAuthRepository
-import com.now.naaga.data.throwable.DataThrowable
-import kotlinx.coroutines.launch
-
-class SettingViewModel(private val authRepository: AuthRepository) : ViewModel() {
-
-    private val _withdrawalStatue = MutableLiveData<Boolean>()
-    val withdrawalStatue: LiveData<Boolean> = _withdrawalStatue
-
-    private val _errorMessage = MutableLiveData<DataThrowable>()
-    val errorMessage: LiveData<DataThrowable> = _errorMessage
-
-    fun withdrawalMember() {
-        viewModelScope.launch {
-            runCatching { authRepository.withdrawalMember() }
-                .onSuccess { _withdrawalStatue.value = it }
-                .onFailure { _errorMessage.value = it as DataThrowable }
-
-        }
-    }
-
-    companion object {
-        val Factory = SettingFactory(DefaultAuthRepository(authDataSource))
-
-        class SettingFactory(private val authRepository: AuthRepository) :
-            ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return SettingViewModel(authRepository) as T
-            }
-        }
-    }
-}
+package com.now.naaga.presentation.settingimport androidx.lifecycle.LiveDataimport androidx.lifecycle.MutableLiveDataimport androidx.lifecycle.ViewModelimport androidx.lifecycle.ViewModelProviderimport androidx.lifecycle.viewModelScopeimport com.now.domain.repository.AuthRepositoryimport com.now.naaga.NaagaApplication.DependencyContainer.authDataSourceimport com.now.naaga.data.repository.DefaultAuthRepositoryimport com.now.naaga.data.throwable.DataThrowableimport kotlinx.coroutines.launchclass SettingViewModel(private val authRepository: AuthRepository) : ViewModel() {    private val _withdrawalStatue = MutableLiveData<Boolean>()    val withdrawalStatue: LiveData<Boolean> = _withdrawalStatue    private val _errorMessage = MutableLiveData<DataThrowable>()    val errorMessage: LiveData<DataThrowable> = _errorMessage    fun withdrawalMember() {        viewModelScope.launch {            runCatching { authRepository.withdrawalMember() }                .onSuccess { _withdrawalStatue.value = it }                .onFailure { _errorMessage.value = it as DataThrowable }        }    }    companion object {        val Factory = SettingFactory(DefaultAuthRepository(authDataSource))        class SettingFactory(private val authRepository: AuthRepository) :            ViewModelProvider.Factory {            override fun <T : ViewModel> create(modelClass: Class<T>): T {                return SettingViewModel(authRepository) as T            }        }    }}

--- a/android/app/src/main/java/com/now/naaga/util/KakaoLoginUtil.kt
+++ b/android/app/src/main/java/com/now/naaga/util/KakaoLoginUtil.kt
@@ -7,7 +7,7 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 
-private const val KAKAO_LOGIN_LOG_TAG = "kakao login"
+const val KAKAO_LOGIN_LOG_TAG = "kakao login"
 private const val KAKAO_LOGIN_FAIL_MESSAGE = "카카오계정으로 로그인 실패"
 private const val KAKAO_LOGIN_SUCCESS_MESSAGE = "카카오계정으로 로그인 성공"
 private const val KAKAO_UNLINK_FAIL_MESSAGE = "연결 끊기 실패"

--- a/android/app/src/main/java/com/now/naaga/util/KakaoLoginUtil.kt
+++ b/android/app/src/main/java/com/now/naaga/util/KakaoLoginUtil.kt
@@ -57,10 +57,8 @@ fun unlinkWithKakao() {
     UserApiClient.instance.unlink { error ->
         if (error != null) {
             Log.e(KAKAO_LOGIN_LOG_TAG, KAKAO_UNLINK_FAIL_MESSAGE, error)
-        }
-        else {
+        } else {
             Log.i(KAKAO_LOGIN_LOG_TAG, KAKAO_UNLINK_SUCCESS_MESSAGE)
         }
     }
 }
-

--- a/android/app/src/main/java/com/now/naaga/util/KakaoLoginUtil.kt
+++ b/android/app/src/main/java/com/now/naaga/util/KakaoLoginUtil.kt
@@ -10,6 +10,8 @@ import com.kakao.sdk.user.UserApiClient
 private const val KAKAO_LOGIN_LOG_TAG = "kakao login"
 private const val KAKAO_LOGIN_FAIL_MESSAGE = "카카오계정으로 로그인 실패"
 private const val KAKAO_LOGIN_SUCCESS_MESSAGE = "카카오계정으로 로그인 성공"
+private const val KAKAO_UNLINK_FAIL_MESSAGE = "연결 끊기 실패"
+private const val KAKAO_UNLINK_SUCCESS_MESSAGE = "연결 끊기 성공. SDK에서 토큰 삭제 됨"
 
 private fun getLoginCallback(doNextAction: (token: String) -> Unit): (OAuthToken?, Throwable?) -> Unit {
     val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
@@ -50,3 +52,15 @@ fun loginWithKakao(context: Context, doNextAction: (token: String) -> Unit) {
         UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
     }
 }
+
+fun unlinkWithKakao() {
+    UserApiClient.instance.unlink { error ->
+        if (error != null) {
+            Log.e(KAKAO_LOGIN_LOG_TAG, KAKAO_UNLINK_FAIL_MESSAGE, error)
+        }
+        else {
+            Log.i(KAKAO_LOGIN_LOG_TAG, KAKAO_UNLINK_SUCCESS_MESSAGE)
+        }
+    }
+}
+

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -105,4 +105,15 @@
     <string name="upload_error_already_exists_nearby_message">근방에 다른 미션장소가 존재해서 추가할 수 없어요!</string>
     <string name="upload_error_post_message">전송에 실패했어요! 다시 시도해주세요!</string>
     <string name="upload_error_insufficient_info_message">모든 정보를 입력해주세요.</string>
+
+    <!-- SettingActivity -->
+    <string name="setting_withdrawal_success_message">"성공적으로 회원 탈퇴 되었습니다."</string>
+    <string name="setting_wrong_error_message">"인증 정보가 잘 못 되었어요!"</string>
+    <string name="setting_expiration_error_message">"인증 정보가 만료 되었어요!"</string>
+
+    <!-- Withdrawal Dialog -->
+    <string name="withdrawal_dialog_title">정말 회원 탈퇴를 하시겠습니까?</string>
+    <string name="withdrawal_dialog_description">나아가와 함께 즐거운 모험을 계속해보세요!</string>
+    <string name="withdrawal_dialog_positive">네</string>
+    <string name="withdrawal_dialog_negative">아니요</string>
 </resources>

--- a/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
+++ b/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
@@ -7,5 +7,5 @@ interface AuthRepository {
         platformAuth: PlatformAuth,
     ): Boolean
 
-    suspend fun withdrawalMember(): Boolean
+    suspend fun withdrawalMember()
 }

--- a/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
+++ b/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
@@ -6,4 +6,6 @@ interface AuthRepository {
     suspend fun getToken(
         platformAuth: PlatformAuth,
     ): Boolean
+
+    suspend fun withdrawalMember(): Boolean
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #329 

## 🛠️ 작업 내용
- [x] 회원 탈퇴 시 서버와의 연결
- [x] 회원 탈퇴 시 카카오와의 연결 후 토큰 삭제해주기
- [x] 설정 뷰에서 회원 탈퇴를 누르면 회원 탈퇴 성공

## 🎯 리뷰 포인트
현재 설정 뷰에서 회원탈퇴를 누르게 되면 서버의 API와 연동 후, 해당 과정이 성공하면 카카오에게도 토큰 정보를 삭제해달라는 `unlink` 함수를 실행시키도록 구현해놓았습니다. 
그리고 만일 회원 탈퇴가 성공적으로 진행되면 회원탈퇴가 성공적으로 진행되었다는 토스트가 뜨고 로그인 페이지로 이동하도록 했습니다. 

여기서 한가지 리뷰어님께 물어보고 싶은점이 있는데, 지금은 그냥 설정뷰에서 회원탈퇴를 누르면 바로 탈퇴가 되는 중입니다. 
혹시 여기서 확인 다이얼로그를 한번 더 띄우거나 하는 추가 로직이 필요할까요? 

## ⏳ 작업 시간
추정 시간:  1h 
실제 시간:  2h 
이유: API의 싱크 맞추기와 Response body가 null 값인 상황을 해결하느라 좀 더 걸렸습니다.
