### PR TITLE
refactor: datasource 의존성 주입 라이브러리 적용

### DIFF
--- a/android/app/src/main/java/com/now/naaga/di/DataSourceModule.kt
+++ b/android/app/src/main/java/com/now/naaga/di/DataSourceModule.kt
@@ -1,0 +1,19 @@
+package com.now.naaga.di
+
+import android.content.Context
+import com.now.naaga.data.local.AuthDataSource
+import com.now.naaga.data.local.DefaultAuthDataSource
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class DataSourceModule {
+    @Singleton
+    @Provides
+    fun provideAuthDatasource(@ApplicationContext context: Context): AuthDataSource = DefaultAuthDataSource(context)
+}

--- a/android/app/src/main/java/com/now/naaga/di/RepositoryModule.kt
+++ b/android/app/src/main/java/com/now/naaga/di/RepositoryModule.kt
@@ -5,7 +5,7 @@ import com.now.domain.repository.AuthRepository
 import com.now.domain.repository.PlaceRepository
 import com.now.domain.repository.RankRepository
 import com.now.domain.repository.StatisticsRepository
-import com.now.naaga.NaagaApplication
+import com.now.naaga.data.local.AuthDataSource
 import com.now.naaga.data.repository.DefaultAdventureRepository
 import com.now.naaga.data.repository.DefaultAuthRepository
 import com.now.naaga.data.repository.DefaultPlaceRepository
@@ -26,7 +26,7 @@ class RepositoryModule {
 
     @Singleton
     @Provides
-    fun provideAuthRepository(): AuthRepository = DefaultAuthRepository(NaagaApplication.authDataSource)
+    fun provideAuthRepository(authDataSource: AuthDataSource): AuthRepository = DefaultAuthRepository(authDataSource)
 
     @Singleton
     @Provides


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #351

## 🛠️ 작업 내용
datasource 의존성 주입 라이브러리 적용

## 📣 참고 사항
### Provides 방식
```kotlin
// 모듈 클래스
@Module
@InstallIn(SingletonComponent::class)
class DataSourceModule {
    @Singleton
    @Provides
    fun provideAuthDatasource(@ApplicationContext context: Context): AuthDataSource = DefaultAuthDataSource(context)
}

// 구현체 클래스
class DefaultAuthDataSource(context: Context) : AuthDataSource
```
- 모듈을 object 혹은 class로 선언해야 합니다.
- 함수에서 직접 반환을 해주기 때문에 interface 혹은 abstract class는 선언이 불가능합니다.
- provideXxx 메서드에서 어떤 인스턴스를 어떻게 구현하여 반환할 것인지 정의되어 있기 때문에 구현체 클래스에는 변화가 없습니다.

### Binds 방식
```kotlin
// 모듈 클래스
@Module
@InstallIn(SingletonComponent::class)
abstract class DataSourceModule {
    @Singleton
    @Binds
    abstract fun bindAuthDatasource(defaultAuthDataSource: DefaultAuthDataSource): AuthDataSource
}

// 구현체 클래스
class DefaultAuthDataSource @Inject constructor(
    @ApplicationContext context: Context
) : AuthDataSource
```
- 모듈을 interface 혹은 abstract class로 선언해야 합니다.
- Provides 방식에서 설명한 것과 반대로 함수에서 직접 반환을 해주지 않기 때문에 interface 혹은 abstract class가 아닌 경우 선언이 불가능합니다.
- bindXxx 메서드에서 함수 파라미터에 구현체를 넣어주기 때문에 구현체 constructor 앞에 `@Inject` 애노테이션을 붙여줘야 합니다. 이 의미는 bindXxx 메서드 파라미터에 이 생성자를 넣어주겠다는 의미입니다.

### 공통점
- @ApplicationContext 애노테이션을 사용하여 ApplicationContext를 받아온다고 명시해주어야 합니다.
- 내부적으로 코드 제너레이터 방식을 사용합니다.

### 차이점
- 두 가지 방식 모두 코드 제너레이터 방식을 사용하지만 생성되는 코드 양의 차이가 있습니다. Provides 방식의 경우 팩토리 코드까지 생성되어 생성되는 코드가 많아지는 반면, Binds 방식의 경우 직접 생성자를 호출하여 함수의 인자로 넣어주기 때문에 팩토리 코드가 생성되지 않아 생성되는 코드의 양이 Provides에 비해 적습니다. 

## 🎯 리뷰 포인트
현재 코드에서는 코드의 통일성을 위해 Provides 방식을 선택하여 진행하였습니다.  
이 PR에 해당하는 리뷰 포인트는 아닙니다. 하지만 고려해보면 좋을 것 같아 남깁니다.  
- Repository 자동 주입을 위해 Provides 방식을 선택했지만 Binds 방식과 정확한 차이를 알지 못해서 선택한 것이라고 느껴집니다. (구현체 클래스에 `@Inject` 애노테이션을 달아줘야 한다는 차이는 있지만요.) 그래서 Provides와 Binds 방식에 대해 어떤 것을 선호하는지와 이유도 있다면 함께 남겨주시면 감사할 것 같습니다 :)  

## ⏳ 작업 시간
추정 시간: 1h  
실제 시간: 1h  