### PR TITLE
fix: 나의 통계 조회 시 성능 저하 문제 해결

### DIFF
--- a/backend/src/main/java/com/now/naaga/game/application/GameService.java
+++ b/backend/src/main/java/com/now/naaga/game/application/GameService.java
@@ -137,11 +137,7 @@ public class GameService {
 
     @Transactional(readOnly = true)
     public Statistic findStatistic(final PlayerRequest playerRequest) {
-        final List<Game> gamesByPlayerId = gameRepository.findByPlayerIdAndGameStatus(playerRequest.playerId(),
-                GameStatus.DONE);
-        final List<GameResult> gameResults = gamesByPlayerId.stream()
-                .map(game -> findGameResultByGameId(game.getId()))
-                .toList();
+        final List<GameResult> gameResults = gameResultRepository.findByPlayerId(playerRequest.playerId());
         final List<GameRecord> gameRecords = gameResults.stream()
                 .map(GameRecord::from).toList();
 

--- a/backend/src/main/java/com/now/naaga/gameresult/domain/GameResult.java
+++ b/backend/src/main/java/com/now/naaga/gameresult/domain/GameResult.java
@@ -3,15 +3,8 @@ package com.now.naaga.gameresult.domain;
 import com.now.naaga.common.domain.BaseEntity;
 import com.now.naaga.game.domain.Game;
 import com.now.naaga.score.domain.Score;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.*;
+
 import java.util.Objects;
 
 @Entity
@@ -27,7 +20,7 @@ public class GameResult extends BaseEntity {
     @Embedded
     private Score score;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "game_id")
     private Game game;
 

--- a/backend/src/main/java/com/now/naaga/gameresult/repository/GameResultRepository.java
+++ b/backend/src/main/java/com/now/naaga/gameresult/repository/GameResultRepository.java
@@ -10,7 +10,7 @@ public interface GameResultRepository extends JpaRepository<GameResult, Long> {
 
     List<GameResult> findByGameId(final Long gameId);
 
-    @Query("SELECT r FROM GameResult r JOIN FETCH r.game LEFT JOIN FETCH r.game.hints Where r.game.player.id = :playerId")
+    @Query("SELECT r FROM GameResult r JOIN FETCH r.game g LEFT JOIN FETCH g.hints Where g.player.id = :playerId")
     List<GameResult> findByPlayerId(@Param("playerId") Long playerId);
 
 }

--- a/backend/src/main/java/com/now/naaga/gameresult/repository/GameResultRepository.java
+++ b/backend/src/main/java/com/now/naaga/gameresult/repository/GameResultRepository.java
@@ -10,7 +10,7 @@ public interface GameResultRepository extends JpaRepository<GameResult, Long> {
 
     List<GameResult> findByGameId(final Long gameId);
 
-    @Query("SELECT r FROM GameResult r JOIN FETCH r.game g LEFT JOIN FETCH g.hints Where g.player.id = :playerId")
+    @Query("SELECT r FROM GameResult r JOIN FETCH r.game g LEFT JOIN FETCH g.hints JOIN FETCH g.place Where g.player.id = :playerId")
     List<GameResult> findByPlayerId(@Param("playerId") Long playerId);
 
 }

--- a/backend/src/main/java/com/now/naaga/gameresult/repository/GameResultRepository.java
+++ b/backend/src/main/java/com/now/naaga/gameresult/repository/GameResultRepository.java
@@ -3,8 +3,14 @@ package com.now.naaga.gameresult.repository;
 import com.now.naaga.gameresult.domain.GameResult;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GameResultRepository extends JpaRepository<GameResult, Long> {
 
     List<GameResult> findByGameId(final Long gameId);
+
+    @Query("SELECT r FROM GameResult r JOIN FETCH r.game LEFT JOIN FETCH r.game.hints Where r.game.player.id = :playerId")
+    List<GameResult> findByPlayerId(@Param("playerId") Long playerId);
+
 }

--- a/backend/src/main/java/com/now/naaga/place/domain/Place.java
+++ b/backend/src/main/java/com/now/naaga/place/domain/Place.java
@@ -6,14 +6,8 @@ import com.now.naaga.common.domain.BaseEntity;
 import com.now.naaga.place.exception.PlaceException;
 import com.now.naaga.place.exception.PlaceExceptionType;
 import com.now.naaga.player.domain.Player;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
+
 import java.util.Objects;
 
 @Entity
@@ -32,7 +26,7 @@ public class Place extends BaseEntity {
 
     private String imageUrl;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
     private Player registeredPlayer;
 

--- a/backend/src/test/java/com/now/naaga/gameresult/application/GameResultServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/gameresult/application/GameResultServiceTest.java
@@ -55,6 +55,7 @@ class GameResultServiceTest {
     private PlaceBuilder placeBuilder;
 
     @Test
+    @Transactional
     void 사용자의_위치가_도착_범위_안이고_엔트타입이_도착이면_게임_결과를_성공으로_생성_후_저장하고_플레이어의_점수를_올린다() {
         //given
         final Player player = playerBuilder.init().build();

--- a/backend/src/test/java/com/now/naaga/gameresult/application/GameResultServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/gameresult/application/GameResultServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 

--- a/backend/src/test/java/com/now/naaga/gameresult/repository/GameResultRepositoryTest.java
+++ b/backend/src/test/java/com/now/naaga/gameresult/repository/GameResultRepositoryTest.java
@@ -1,0 +1,85 @@
+package com.now.naaga.gameresult.repository;
+
+import com.now.naaga.common.builder.GameBuilder;
+import com.now.naaga.common.builder.GameResultBuilder;
+import com.now.naaga.common.builder.PlaceBuilder;
+import com.now.naaga.common.builder.PlayerBuilder;
+import com.now.naaga.game.domain.Game;
+import com.now.naaga.gameresult.domain.GameResult;
+import com.now.naaga.place.domain.Place;
+import com.now.naaga.player.domain.Player;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static com.now.naaga.common.fixture.PositionFixture.잠실_루터회관_정문_좌표;
+import static com.now.naaga.common.fixture.PositionFixture.잠실역_교보문고_좌표;
+import static com.now.naaga.game.domain.GameStatus.DONE;
+import static com.now.naaga.gameresult.domain.ResultType.SUCCESS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Sql("/truncate.sql")
+@SpringBootTest
+class GameResultRepositoryTest {
+
+    @Autowired
+    private GameResultRepository gameResultRepository;
+
+    @Autowired
+    private PlayerBuilder playerBuilder;
+    @Autowired
+    private PlaceBuilder placeBuilder;
+    @Autowired
+    private GameResultBuilder gameResultBuilder;
+    @Autowired
+    private GameBuilder gameBuilder;
+
+    @Test
+    void 맴버아이디로_게임결과를_조회했을때_게임결과에_모든정보가_조회된다() {
+        //given
+        final Player player = playerBuilder.init()
+                .build();
+
+        final Place place = placeBuilder.init()
+                .position(잠실역_교보문고_좌표)
+                .registeredPlayer(player)
+                .build();
+
+        final Game game1 = gameBuilder.init()
+                .startPosition(잠실_루터회관_정문_좌표)
+                .player(player)
+                .place(place)
+                .gameStatus(DONE)
+                .build();
+
+        final Game game2 = gameBuilder.init()
+                .startPosition(잠실_루터회관_정문_좌표)
+                .player(player)
+                .place(place)
+                .gameStatus(DONE)
+                .build();
+
+        final GameResult gameResult1 = gameResultBuilder.init()
+                .resultType(SUCCESS)
+                .game(game1)
+                .build();
+        final GameResult gameResult2 = gameResultBuilder.init()
+                .resultType(SUCCESS)
+                .game(game2)
+                .build();
+
+        // when
+        List<GameResult> gameResults = gameResultRepository.findByPlayerId(player.getId());
+
+        // then
+        assertThat(gameResults).containsExactlyInAnyOrder(gameResult1, gameResult2);
+
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #356 

## 🛠️ 작업 내용
- [x] 문제 파악 후 DB에 날라가 횟수 수정
- [x] 가능하면 해당 로직의 개선점 정리

## 🎯 리뷰 포인트
### 상황
1. List<Game>을 PlayerId 로 조회 : 쿼리 1번
2. List<Game>에 대한 GameResult를 각각 조회 : 쿼리 N번
3. GameResult -> GameRecord 변환 과정에서 Game의 힌트 조회 : 쿼리 N번 (GameRecord에서 힌트의 정보가 필요하기 때문)

- 예시
  - 플레이어가 10번의 게임을 마쳤을때, </br> 1번의 상황으로 쿼리 1번, </br>2번의 상황으로 쿼리 10번, </br>3번의 상황으로 쿼리 10번이 발생하여</br>총 21개의 쿼리가 발생함
  
### 해결 방안
  - 두번의 조인 쿼리문을 작성하여 게임 결과를 가져올때 게임의 대한 모든 정보(힌트까지) 모두 조회하도록 쿼리를 작성하였습니다.


## ⏳ 작업 시간
추정 시간:   1시간
실제 시간:   1시간
