### PR TITLE
feat: 장소 검수 기능 뼈대코드 설계 및 구현

### DIFF
--- a/backend/src/main/java/com/now/naaga/temporaryplace/domain/TemporaryPlace.java
+++ b/backend/src/main/java/com/now/naaga/temporaryplace/domain/TemporaryPlace.java
@@ -1,0 +1,112 @@
+package com.now.naaga.temporaryplace.domain;
+
+import com.now.naaga.common.domain.BaseEntity;
+import com.now.naaga.place.domain.Position;
+import com.now.naaga.player.domain.Player;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.Objects;
+
+@Entity
+public class TemporaryPlace extends BaseEntity {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    @Embedded
+    private Position position;
+
+    private String imageUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "player_id")
+    private Player registeredPlayer;
+
+    protected TemporaryPlace() {
+    }
+
+    public TemporaryPlace(final String name,
+                          final String description,
+                          final Position position,
+                          final String imageUrl,
+                          final Player registeredPlayer) {
+        this(null, name, description, position, imageUrl, registeredPlayer);
+    }
+
+    public TemporaryPlace(final Long id,
+                          final String name,
+                          final String description,
+                          final Position position,
+                          final String imageUrl,
+                          final Player registeredPlayer) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.position = position;
+        this.imageUrl = imageUrl;
+        this.registeredPlayer = registeredPlayer;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Position getPosition() {
+        return position;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public Player getRegisteredPlayer() {
+        return registeredPlayer;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TemporaryPlace that = (TemporaryPlace) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "TemporaryPlace{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", description='" + description + '\'' +
+                ", position=" + position +
+                ", imageUrl='" + imageUrl + '\'' +
+                ", registeredPlayerId=" + registeredPlayer.getId() +
+                '}';
+    }
+}

--- a/backend/src/main/java/com/now/naaga/temporaryplace/presentation/TemporaryPlaceController.java
+++ b/backend/src/main/java/com/now/naaga/temporaryplace/presentation/TemporaryPlaceController.java
@@ -1,0 +1,9 @@
+package com.now.naaga.temporaryplace.presentation;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/temporary-places")
+@RestController
+public class TemporaryPlaceController {
+}

--- a/backend/src/main/java/com/now/naaga/temporaryplace/repository/TemporaryPlaceRepository.java
+++ b/backend/src/main/java/com/now/naaga/temporaryplace/repository/TemporaryPlaceRepository.java
@@ -1,0 +1,8 @@
+package com.now.naaga.temporaryplace.repository;
+
+
+import com.now.naaga.temporaryplace.domain.TemporaryPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemporaryPlaceRepository extends JpaRepository<TemporaryPlace, Long> {
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #372 

## 🛠️ 작업 내용
- [x] 장소 검수 기능 뼈대코드 설계
- [x] 장소 검수 관련 엔티티 구현
- [x] 장소 검수 관련 컨트롤러 구현
- [x] 장소 검수 관련 레포지토리 구현

## 🎯 리뷰 포인트

# 장소 검수 도메인에 대한 패키지 분리

장소 검수 도메인과 장소 도메인의 내용이 완전히 같습니다. 따라서 `장소 검수 도메인이 기존의 place 패키지 내부에 들어가야할까?` 를 고민하게 되었는데요!

도메인의 생명주기 관점에서 보았을 때, 장소 검수 도메인의 생성/파괴 시점과 장소 도메인의 생성/파괴 시점이 서로 다릅니다.

다만, 장소 검수 후에 장소 등록 시나리오를 거쳤을 경우에는, 장소 검수 도메인의 파괴와 장소 도메인의 생성 로직이 한 트랜잭션 안에 물려야합니다.

때문에, 이 경우에는 꽤 많은 도메인 제약사항을 공유하고 있다고 생각하긴 했습니다만, 장소 검수 후 등록 반려가 되는 시나리오에서는 생명주기가 완전히 분리되어버리기 때문에.. 복합적으로 고려했을 때, 대부분의 경우에서 생명주기가 다르다고 판단, 패키지를 분리하게 되었습니다.

# 장소 테이블과 장소 검수에 대한 테이블 분리

기존 place 테이블에 검수 flag 값을 두어서 한 테이블 안에서 관리를 할 수도 있었습니다.

다만 이럴 경우에, place 테이블 안에는 실제 인게임에서 등록된 장소와, 아직 검수가 필요한 장소가 혼재되어서 place 테이블이 비대해질 수 있다는 문제점이 존재했습니다.

실제로 우리 팀의 비즈니스 시나리오에서는, 인게임 등록 장소보다 검수가 필요한 장소의 수가 압도적으로 많습니다.

이 경우에서, 만약 인게임 등록 장소만을 조회하기 위해 place 테이블 조회 쿼리가 발생하면, 필요 이상으로 비대한 place 테이블에 대해 테이블 풀스캔이 일어나야합니다. (중복이 많기 때문에 카디널리티가 굉장히 낮으므로) 이는 인덱스로도 개선할 수 없는 문제입니다.

따라서, 검수가 필요한 장소들의 데이터로 인해 인게임 사용성이 떨어지면 안된다고 판단하였습니다.

또한, 기존에 사용하던 place 에 대한 쿼리들에 WHERE 절을 모두 붙여주어야하고, 앞으로 생겨날 쿼리들에도 WHERE 절을 붙여주어야 합니다.

이는 리팩터링 유지보수 관점에서나, 미래의 생산성 측면에서나 큰 장점이 없다고 판단했습니다.

위의 문제들은 근본적인 테이블 분리를 통해 모두 해결 가능합니다.

또한, 테이블 분리를 통해 의미적으로 더욱 확실하게 분리시켜주는 것이 직관적이라 생각했습니다.

위의 이유들로, 장소 테이블과 장소 검수 테이블에 대한 테이블 분리 결정을 내리게 되었습니다! 😁

## ⏳ 작업 시간
추정 시간:   2시간
실제 시간:   15분
