### PR TITLE
fix: OkHttpClient의 interceptor를 AuthInterceptor로 변경

### DIFF
--- a/android/app/src/main/java/com/now/naaga/di/ServiceModule.kt
+++ b/android/app/src/main/java/com/now/naaga/di/ServiceModule.kt
@@ -2,7 +2,7 @@ package com.now.naaga.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.now.naaga.BuildConfig
-import com.now.naaga.NaagaApplication
+import com.now.naaga.data.remote.retrofit.AuthInterceptor
 import com.now.naaga.data.remote.retrofit.service.AdventureService
 import com.now.naaga.data.remote.retrofit.service.AuthService
 import com.now.naaga.data.remote.retrofit.service.PlaceService
@@ -13,7 +13,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
-import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -26,24 +25,9 @@ class ServiceModule {
 
     @Singleton
     @Provides
-    fun createInterceptor(): Interceptor = Interceptor { chain ->
-        val token: String = NaagaApplication.authDataSource.getAccessToken() ?: ""
-        with(chain) {
-            val newRequest = request().newBuilder()
-                .addHeader("Authorization", "Bearer $token")
-                .addHeader("Content-Type", "application/json")
-                .build()
-            proceed(newRequest)
-        }
-    }
-
-    @Singleton
-    @Provides
-    fun createOkHttpClient(interceptor: Interceptor): OkHttpClient {
-        return OkHttpClient.Builder().apply {
-            addInterceptor(interceptor)
-        }.build()
-    }
+    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder().apply {
+        addInterceptor(AuthInterceptor())
+    }.build()
 
     @Singleton
     @Provides


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #371 

## 🛠️ 작업 내용
- [x] OkHttpClient의 interceptor를 AuthInterceptor로 변경하였고, 직접 생성하여 넣어주도록 변경
- [x] OkHttpClient의 provide 메서드 변경

## 🎯 리뷰 포인트
OkHttpClient의 interceptor를 AuthInterceptor로 변경하였고, 이 때 직접 생성하여 넣어주도록 변경했습니다. 이렇게 한 이유는 AuthInterceptor는 재사용되지 않기 때문에 힐트가 싱글턴으로 관리하고 있을 필요가 없다고 생각했어요. 이 부분에 대해 어떻게 생각하는지 남겨주시면 좋을 것 같습니다!

## ⏳ 작업 시간
추정 시간: 30m  
실제 시간: 30m  
직접 작성한 코드에서 발생한 문제가 아니라서 이유를 찾는데 오래 걸렸네요..