### PR TITLE
feat: 검수 중인 장소에 대한 장소 등록 허가 API 구현

### DIFF
--- a/backend/src/main/java/com/now/naaga/auth/presentation/interceptor/ManagerAuthInterceptor.java
+++ b/backend/src/main/java/com/now/naaga/auth/presentation/interceptor/ManagerAuthInterceptor.java
@@ -20,7 +20,7 @@ public class ManagerAuthInterceptor implements HandlerInterceptor {
 
     public static final int AUTH_HEADER_INFO_SIZE = 2;
 
-    public static final String AUTH_HEADER_TYPE = "Basic ";
+    public static final String AUTH_HEADER_TYPE = "Basic";
 
     @Value("${manager.id}")
     private String id;
@@ -41,12 +41,12 @@ public class ManagerAuthInterceptor implements HandlerInterceptor {
         if (header == null) {
             throw new AuthException(NOT_EXIST_HEADER);
         }
-        final String decodedHeader = new String(Base64.getDecoder().decode(header));
-        if (!decodedHeader.startsWith(AUTH_HEADER_TYPE)) {
+        final String[] authHeader = header.split(" ");
+        if (!AUTH_HEADER_TYPE.equalsIgnoreCase(authHeader[0])) {
             throw new AuthException(INVALID_HEADER);
         }
-        final String decodedHeaderWithoutType = decodedHeader.replace(AUTH_HEADER_TYPE, "");
-        final String[] idAndPassword = decodedHeaderWithoutType.split(":");
+        final String decodedHeader = new String(Base64.getDecoder().decode(authHeader[1]));
+        final String[] idAndPassword = decodedHeader.split(":");
         if (idAndPassword.length != AUTH_HEADER_INFO_SIZE) {
             throw new AuthException(INVALID_HEADER);
         }

--- a/backend/src/main/java/com/now/naaga/common/config/WebConfig.java
+++ b/backend/src/main/java/com/now/naaga/common/config/WebConfig.java
@@ -3,7 +3,9 @@ package com.now.naaga.common.config;
 import com.now.naaga.auth.presentation.argumentresolver.MemberAuthArgumentResolver;
 import com.now.naaga.auth.presentation.argumentresolver.PlayerArgumentResolver;
 import com.now.naaga.auth.presentation.interceptor.AuthInterceptor;
+import com.now.naaga.auth.presentation.interceptor.ManagerAuthInterceptor;
 import com.now.naaga.common.presentation.interceptor.RequestMatcherInterceptor;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -12,8 +14,6 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -24,20 +24,25 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final AuthInterceptor authInterceptor;
 
+    private final ManagerAuthInterceptor managerAuthInterceptor;
+
     @Value("${manager.origin-url}")
     private String managerUriPath;
 
     public WebConfig(final PlayerArgumentResolver playerArgumentResolver,
                      final MemberAuthArgumentResolver memberAuthArgumentResolver,
-                     final AuthInterceptor authInterceptor) {
+                     final AuthInterceptor authInterceptor,
+                     final ManagerAuthInterceptor managerAuthInterceptor) {
         this.playerArgumentResolver = playerArgumentResolver;
         this.memberAuthArgumentResolver = memberAuthArgumentResolver;
         this.authInterceptor = authInterceptor;
+        this.managerAuthInterceptor = managerAuthInterceptor;
     }
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(mapAuthInterceptor());
+        registry.addInterceptor(mapManagerAuthInterceptor());
     }
 
     private HandlerInterceptor mapAuthInterceptor() {
@@ -51,7 +56,13 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludeRequestPattern("/**/*.gif")
                 .excludeRequestPattern("/**/*.ico")
                 .excludeRequestPattern("/ranks")
-                .excludeRequestPattern("/**", HttpMethod.OPTIONS);
+                .excludeRequestPattern("/**", HttpMethod.OPTIONS)
+                .excludeRequestPattern("/places", HttpMethod.POST);
+    }
+
+    private HandlerInterceptor mapManagerAuthInterceptor() {
+        return new RequestMatcherInterceptor(managerAuthInterceptor)
+                .includeRequestPattern("/places", HttpMethod.POST);
     }
 
     @Override

--- a/backend/src/main/java/com/now/naaga/place/application/PlaceService.java
+++ b/backend/src/main/java/com/now/naaga/place/application/PlaceService.java
@@ -69,6 +69,8 @@ public class PlaceService {
     }
 
     public Place createPlace(final CreatePlaceCommand createPlaceCommand) {
+        placeCheckService.checkOtherPlaceNearby(createPlaceCommand.position());
+
         final Long registeredPlayerId = createPlaceCommand.registeredPlayerId();
         final Player registeredPlayer = playerService.findPlayerById(registeredPlayerId);
         final Place place = new Place(createPlaceCommand.name(),
@@ -76,30 +78,9 @@ public class PlaceService {
                                       createPlaceCommand.position(),
                                       createPlaceCommand.imageUrl(),
                                       registeredPlayer);
+
         placeRepository.save(place);
         temporaryPlaceService.deleteById(createPlaceCommand.temporaryPlaceId());
         return place;
     }
-
-    // TODO: 2023/10/03 장소 검수 API 구현 이후 삭제 예정
-//    public Place createPlace(final CreatePlaceCommand createPlaceCommand) {
-//        final Position position = createPlaceCommand.position();
-//        placeCheckService.checkOtherPlaceNearby(position);
-//        final File uploadPath = fileManager.save(createPlaceCommand.imageFile());
-//        try {
-//            final Long playerId = createPlaceCommand.playerId();
-//            final Player registeredPlayer = playerService.findPlayerById(playerId);
-//            final Place place = new Place(
-//                    createPlaceCommand.name(),
-//                    createPlaceCommand.description(),
-//                    position,
-//                    fileManager.convertToUrlPath(uploadPath),
-//                    registeredPlayer);
-//            placeRepository.save(place);
-//            return place;
-//        } catch (final RuntimeException exception) {
-//            uploadPath.delete();
-//            throw exception;
-//        }
-//    }
 }

--- a/backend/src/main/java/com/now/naaga/place/application/dto/CreatePlaceCommand.java
+++ b/backend/src/main/java/com/now/naaga/place/application/dto/CreatePlaceCommand.java
@@ -2,24 +2,24 @@ package com.now.naaga.place.application.dto;
 
 import com.now.naaga.place.domain.Position;
 import com.now.naaga.place.presentation.dto.CreatePlaceRequest;
-import com.now.naaga.player.presentation.dto.PlayerRequest;
-import org.springframework.web.multipart.MultipartFile;
 
-public record CreatePlaceCommand(Long playerId,
-                                 String name,
+public record CreatePlaceCommand(String name,
                                  String description,
                                  Position position,
-                                 MultipartFile imageFile) {
+                                 String imageUrl,
+                                 Long registeredPlayerId,
+                                 Long temporaryPlaceId) {
 
-    public static CreatePlaceCommand of(final PlayerRequest playerRequest,
-                                        final CreatePlaceRequest createPlaceRequest) {
+    public static CreatePlaceCommand from(final CreatePlaceRequest createPlaceRequest) {
         Position position = Position.of(createPlaceRequest.latitude(), createPlaceRequest.longitude());
+
         return new CreatePlaceCommand(
-                playerRequest.playerId(),
                 createPlaceRequest.name(),
                 createPlaceRequest.description(),
                 position,
-                createPlaceRequest.imageFile()
+                createPlaceRequest.imageUrl(),
+                createPlaceRequest.registeredPlayerId(),
+                createPlaceRequest.temporaryPlaceId()
         );
     }
 }

--- a/backend/src/main/java/com/now/naaga/place/presentation/PlaceController.java
+++ b/backend/src/main/java/com/now/naaga/place/presentation/PlaceController.java
@@ -14,9 +14,9 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -54,14 +54,26 @@ public class PlaceController {
     }
 
     @PostMapping
-    public ResponseEntity<PlaceResponse> createPlace(@Auth final PlayerRequest playerRequest,
-                                                     @ModelAttribute final CreatePlaceRequest createPlaceRequest) {
-        CreatePlaceCommand createPlaceCommand = CreatePlaceCommand.of(playerRequest, createPlaceRequest);
-        final Place savedPlace = placeService.createPlace(createPlaceCommand);
-        final PlaceResponse response = PlaceResponse.from(savedPlace);
+    public ResponseEntity<PlaceResponse> createPlace(@RequestBody final CreatePlaceRequest createPlaceRequest) {
+        final CreatePlaceCommand createPlaceCommand = CreatePlaceCommand.from(createPlaceRequest);
+        final Place place = placeService.createPlace(createPlaceCommand);
+        final PlaceResponse response = PlaceResponse.from(place);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .location(URI.create("/places/" + savedPlace.getId()))
+                .location(URI.create("/places/" + place.getId()))
                 .body(response);
     }
+
+// TODO: 2023/10/03 장소 검수 API 구현 이후 삭제 예정
+//    @PostMapping
+//    public ResponseEntity<PlaceResponse> createPlace(@Auth final PlayerRequest playerRequest,
+//                                                     @ModelAttribute final CreatePlaceRequest createPlaceRequest) {
+//        CreatePlaceCommand createPlaceCommand = CreatePlaceCommand.of(playerRequest, createPlaceRequest);
+//        final Place savedPlace = placeService.createPlace(createPlaceCommand);
+//        final PlaceResponse response = PlaceResponse.from(savedPlace);
+//        return ResponseEntity
+//                .status(HttpStatus.CREATED)
+//                .location(URI.create("/places/" + savedPlace.getId()))
+//                .body(response);
+//    }
 }

--- a/backend/src/main/java/com/now/naaga/place/presentation/PlaceController.java
+++ b/backend/src/main/java/com/now/naaga/place/presentation/PlaceController.java
@@ -63,17 +63,4 @@ public class PlaceController {
                 .location(URI.create("/places/" + place.getId()))
                 .body(response);
     }
-
-// TODO: 2023/10/03 장소 검수 API 구현 이후 삭제 예정
-//    @PostMapping
-//    public ResponseEntity<PlaceResponse> createPlace(@Auth final PlayerRequest playerRequest,
-//                                                     @ModelAttribute final CreatePlaceRequest createPlaceRequest) {
-//        CreatePlaceCommand createPlaceCommand = CreatePlaceCommand.of(playerRequest, createPlaceRequest);
-//        final Place savedPlace = placeService.createPlace(createPlaceCommand);
-//        final PlaceResponse response = PlaceResponse.from(savedPlace);
-//        return ResponseEntity
-//                .status(HttpStatus.CREATED)
-//                .location(URI.create("/places/" + savedPlace.getId()))
-//                .body(response);
-//    }
 }

--- a/backend/src/main/java/com/now/naaga/place/presentation/dto/CreatePlaceRequest.java
+++ b/backend/src/main/java/com/now/naaga/place/presentation/dto/CreatePlaceRequest.java
@@ -1,10 +1,10 @@
 package com.now.naaga.place.presentation.dto;
 
-import org.springframework.web.multipart.MultipartFile;
-
 public record CreatePlaceRequest(String name,
                                  String description,
                                  Double latitude,
                                  Double longitude,
-                                 MultipartFile imageFile) {
+                                 String imageUrl,
+                                 Long registeredPlayerId,
+                                 Long temporaryPlaceId) {
 }

--- a/backend/src/main/java/com/now/naaga/place/presentation/dto/PlaceResponse.java
+++ b/backend/src/main/java/com/now/naaga/place/presentation/dto/PlaceResponse.java
@@ -2,7 +2,6 @@ package com.now.naaga.place.presentation.dto;
 
 import com.now.naaga.place.domain.Place;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record PlaceResponse(Long id,
                             String name,
@@ -22,7 +21,7 @@ public record PlaceResponse(Long id,
 
     public static List<PlaceResponse> convertToPlaceResponses(final List<Place> places) {
         return places.stream()
-                .map(PlaceResponse::from)
-                .collect(Collectors.toList());
+                     .map(PlaceResponse::from)
+                     .toList();
     }
 }

--- a/backend/src/main/java/com/now/naaga/temporaryplace/application/TemporaryPlaceService.java
+++ b/backend/src/main/java/com/now/naaga/temporaryplace/application/TemporaryPlaceService.java
@@ -1,0 +1,13 @@
+package com.now.naaga.temporaryplace.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class TemporaryPlaceService {
+
+    public void deleteById(final Long id) {
+        return;
+    }
+}

--- a/backend/src/test/java/com/now/naaga/auth/presentation/interceptor/ManagerAuthInterceptorTest.java
+++ b/backend/src/test/java/com/now/naaga/auth/presentation/interceptor/ManagerAuthInterceptorTest.java
@@ -36,12 +36,12 @@ class ManagerAuthInterceptorTest {
     @Test
     void Auth_헤더를_Base64_헤더를_디코딩해서_관리자_로그인을_처리한다() throws Exception {
         // given
-        final String s = "Basic "+id+":"+password;
+        final String s = id + ":" + password;
         final String authHeader = new String(Base64.getEncoder().encode(s.getBytes()));
         final MockHttpServletRequest request = new MockHttpServletRequest();
         final MockHttpServletResponse response = new MockHttpServletResponse();
         final Controller controller = Mockito.mock(Controller.class);
-        request.addHeader("Authorization", authHeader);
+        request.addHeader("Authorization", "Basic " + authHeader);
 
         // when
         final boolean expected = managerAuthInterceptor.preHandle(request, response, controller);
@@ -53,12 +53,12 @@ class ManagerAuthInterceptorTest {
     @Test
     void 잘못된_관리자_정보를_입력하면_예외를_발생한다() throws Exception {
         // given
-        final String s = "Basic wrongId:wrongPW";
+        final String s = "wrongId:wrongPW";
         final String authHeader = new String(Base64.getEncoder().encode(s.getBytes()));
         final MockHttpServletRequest request = new MockHttpServletRequest();
         final MockHttpServletResponse response = new MockHttpServletResponse();
         final Controller controller = Mockito.mock(Controller.class);
-        request.addHeader("Authorization", authHeader);
+        request.addHeader("Authorization", "Basic " + authHeader);
 
         // when & then
         assertThatThrownBy(() -> managerAuthInterceptor.preHandle(request, response, controller)).isInstanceOf(AuthException.class);

--- a/backend/src/test/java/com/now/naaga/place/application/PlaceServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/place/application/PlaceServiceTest.java
@@ -1,0 +1,73 @@
+package com.now.naaga.place.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.now.naaga.common.builder.PlayerBuilder;
+import com.now.naaga.place.application.dto.CreatePlaceCommand;
+import com.now.naaga.place.domain.Place;
+import com.now.naaga.place.domain.Position;
+import com.now.naaga.player.domain.Player;
+import com.now.naaga.temporaryplace.application.TemporaryPlaceService;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Sql("/truncate.sql")
+@ActiveProfiles("test")
+@SpringBootTest
+class PlaceServiceTest {
+
+    @MockBean
+    private TemporaryPlaceService temporaryPlaceService;
+
+    @Autowired
+    private PlaceService placeService;
+
+    @Autowired
+    private PlayerBuilder playerBuilder;
+
+    @Transactional
+    @Test
+    void 장소를_등록한_뒤_기존의_검수_장소_데이터는_삭제한다() {
+        // given
+        final Player player = playerBuilder.init()
+                                           .build();
+
+        final Long temporaryPlaceId = 1L;
+
+        final CreatePlaceCommand createPlaceCommand = new CreatePlaceCommand("루터회관",
+                                                                             "이곳은 루터회관이다 알겠냐",
+                                                                             Position.of(1.23, 4.56),
+                                                                             "image/url",
+                                                                             player.getId(),
+                                                                             temporaryPlaceId);
+
+        // when
+        final Place actual = placeService.createPlace(createPlaceCommand);
+
+        // then
+        final Place expected = new Place(createPlaceCommand.name(),
+                                         createPlaceCommand.description(),
+                                         createPlaceCommand.position(),
+                                         createPlaceCommand.imageUrl(),
+                                         player);
+
+        assertSoftly(softAssertions -> {
+            assertThat(actual).usingRecursiveComparison()
+                              .ignoringExpectedNullFields()
+                              .isEqualTo(expected);
+            verify(temporaryPlaceService, times(1)).deleteById(temporaryPlaceId);
+        });
+    }
+}

--- a/backend/src/test/java/com/now/naaga/place/application/PlaceServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/place/application/PlaceServiceTest.java
@@ -2,13 +2,18 @@ package com.now.naaga.place.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.now.naaga.common.builder.PlaceBuilder;
 import com.now.naaga.common.builder.PlayerBuilder;
+import com.now.naaga.common.exception.BaseExceptionType;
 import com.now.naaga.place.application.dto.CreatePlaceCommand;
 import com.now.naaga.place.domain.Place;
 import com.now.naaga.place.domain.Position;
+import com.now.naaga.place.exception.PlaceException;
+import com.now.naaga.place.exception.PlaceExceptionType;
 import com.now.naaga.player.domain.Player;
 import com.now.naaga.temporaryplace.application.TemporaryPlaceService;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -33,6 +38,9 @@ class PlaceServiceTest {
 
     @Autowired
     private PlaceService placeService;
+
+    @Autowired
+    private PlaceBuilder placeBuilder;
 
     @Autowired
     private PlayerBuilder playerBuilder;
@@ -69,5 +77,31 @@ class PlaceServiceTest {
                               .isEqualTo(expected);
             verify(temporaryPlaceService, times(1)).deleteById(temporaryPlaceId);
         });
+    }
+
+    @Test
+    void 장소_등록_시_주변_반경_20M_내에_등록된_장소가_존재한다면_예외가_발생한다() {
+        // given
+        final Player player = playerBuilder.init()
+                                           .build();
+
+        placeBuilder.init()
+                    .position(Position.of(1.234567, 1.234567))
+                    .build();
+
+        final CreatePlaceCommand createPlaceCommand = new CreatePlaceCommand("루터회관",
+                                                                             "이곳은 루터회관이다 알겠냐",
+                                                                             Position.of(1.23456, 1.23456),
+                                                                             "image/url",
+                                                                             player.getId(),
+                                                                             1L);
+
+        // when
+        final BaseExceptionType baseExceptionType = assertThrows(PlaceException.class,
+                                                                 () -> placeService.createPlace(createPlaceCommand)
+                                                                ).exceptionType();
+
+        // then
+        assertThat(baseExceptionType).isEqualTo(PlaceExceptionType.ALREADY_EXIST_NEARBY);
     }
 }

--- a/backend/src/test/java/com/now/naaga/place/presentation/PlaceControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/place/presentation/PlaceControllerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
@@ -44,6 +45,12 @@ public class PlaceControllerTest extends CommonControllerTest {
     @Autowired
     private PlaceBuilder placeBuilder;
 
+    @Value("${manager.id}")
+    private String id;
+
+    @Value("${manager.password}")
+    private String password;
+
     @BeforeEach
     protected void setUp() {
         super.setUp();
@@ -54,9 +61,6 @@ public class PlaceControllerTest extends CommonControllerTest {
         // given
         final Player player = playerBuilder.init()
                                            .build();
-
-        final AuthToken generate = authTokenGenerator.generate(player.getMember(), 1L, AuthType.KAKAO);
-        final String accessToken = generate.getAccessToken();
 
         final CreatePlaceRequest createPlaceRequest = new CreatePlaceRequest("루터회관",
                                                                              "이곳은 역사와 전통이 깊은 루터회관입니다.",
@@ -69,7 +73,7 @@ public class PlaceControllerTest extends CommonControllerTest {
         // when
         final ExtractableResponse<Response> extract = given()
                 .log().all()
-                .header("Authorization", "Bearer " + accessToken)
+                .auth().preemptive().basic(id, password)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(createPlaceRequest)
                 .when()

--- a/backend/src/test/java/com/now/naaga/place/presentation/PlaceControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/place/presentation/PlaceControllerTest.java
@@ -100,57 +100,6 @@ public class PlaceControllerTest extends CommonControllerTest {
         });
     }
 
-    // TODO: 2023/10/03 장소 검수 API 구현 이후 삭제 예정
-//    @Test
-//    void 장소_추가_요청_시_주변_20미터_내에_이미_등록된_목적지가_있다면_예외를_응답한다() throws FileNotFoundException {
-//        //given
-//        final Player player = playerBuilder.init()
-//                                           .build();
-//
-//        placeBuilder.init()
-//                    .registeredPlayer(player)
-//                    .position(서울_좌표)
-//                    .build();
-//
-//        final Place seoulPlace = PLACE();
-//
-//        final AuthToken generate = authTokenGenerator.generate(player.getMember(), 1L, AuthType.KAKAO);
-//        final String accessToken = generate.getAccessToken();
-//
-//        //when
-//        final ExtractableResponse<Response> extract = given()
-//                .log().all()
-//                .multiPart(new MultiPartSpecBuilder(seoulPlace.getName()).controlName("name").charset(StandardCharsets.UTF_8).build())
-//                .multiPart(new MultiPartSpecBuilder(seoulPlace.getDescription()).controlName("description").charset(StandardCharsets.UTF_8).build())
-//                .multiPart(
-//                        new MultiPartSpecBuilder(seoulPlace.getPosition().getLatitude().setScale(6, RoundingMode.HALF_DOWN).doubleValue()).controlName("latitude").charset(StandardCharsets.UTF_8)
-//                                                                                                                                          .build())
-//                .multiPart(
-//                        new MultiPartSpecBuilder(seoulPlace.getPosition().getLongitude().setScale(6, RoundingMode.HALF_DOWN).doubleValue()).controlName("longitude").charset(StandardCharsets.UTF_8)
-//                                                                                                                                           .build())
-//                .multiPart(new MultiPartSpecBuilder(new FileInputStream(new File("src/test/java/com/now/naaga/place/fixture/루터회관.png"))).controlName("imageFile").charset(StandardCharsets.UTF_8)
-//                                                                                                                                        .fileName("src/test/java/com/now/naaga/place/fixture/루터회관.png")
-//                                                                                                                                        .mimeType("image/png").build())
-//                .header("Authorization", "Bearer " + accessToken)
-//                .when()
-//                .post("/places")
-//                .then()
-//                .log().all()
-//                .extract();
-//        final int statusCode = extract.statusCode();
-//        final ExceptionResponse actual = extract.as(ExceptionResponse.class);
-//        PlaceExceptionType exceptionType = PlaceExceptionType.ALREADY_EXIST_NEARBY;
-//        ExceptionResponse expected = new ExceptionResponse(exceptionType.errorCode(), exceptionType.errorMessage());
-//
-//        //then
-//        assertSoftly(softAssertions -> {
-//            softAssertions.assertThat(statusCode).isEqualTo(HttpStatus.BAD_REQUEST.value());
-//            softAssertions.assertThat(expected)
-//                          .usingRecursiveComparison()
-//                          .isEqualTo(actual);
-//        });
-//    }
-
     @Test
     void 장소를_아이디로_조회한다() {
         //given

--- a/backend/src/test/java/com/now/naaga/place/presentation/PlaceControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/place/presentation/PlaceControllerTest.java
@@ -1,5 +1,8 @@
 package com.now.naaga.place.presentation;
 
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,40 +12,27 @@ import com.now.naaga.auth.infrastructure.jwt.AuthTokenGenerator;
 import com.now.naaga.common.CommonControllerTest;
 import com.now.naaga.common.builder.PlaceBuilder;
 import com.now.naaga.common.builder.PlayerBuilder;
-import com.now.naaga.common.exception.ExceptionResponse;
-import com.now.naaga.common.infrastructure.FileManager;
 import com.now.naaga.place.domain.Place;
-import com.now.naaga.place.exception.PlaceExceptionType;
+import com.now.naaga.place.domain.Position;
+import com.now.naaga.place.presentation.dto.CoordinateResponse;
+import com.now.naaga.place.presentation.dto.CreatePlaceRequest;
 import com.now.naaga.place.presentation.dto.PlaceResponse;
 import com.now.naaga.player.domain.Player;
-import io.restassured.builder.MultiPartSpecBuilder;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.math.RoundingMode;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-
-import static com.now.naaga.common.fixture.PlaceFixture.PLACE;
-import static com.now.naaga.common.fixture.PositionFixture.서울_좌표;
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(ReplaceUnderscores.class)
+@ActiveProfiles("test")
 public class PlaceControllerTest extends CommonControllerTest {
 
     @Autowired
@@ -54,117 +44,108 @@ public class PlaceControllerTest extends CommonControllerTest {
     @Autowired
     private PlaceBuilder placeBuilder;
 
-    @MockBean
-    private FileManager<MultipartFile> fileManager;
-
     @BeforeEach
     protected void setUp() {
         super.setUp();
     }
 
     @Test
-    void 장소_추가_요청을_받으면_추가된_장소_정보를_응답한다() throws FileNotFoundException {
-        //given
+    void 장소_등록_요청이_성공하면_201_상태코드와_생성된_장소를_응답한다() {
+        // given
         final Player player = playerBuilder.init()
                                            .build();
-
-        final Place place = PLACE();
-
-        when(fileManager.save(any())).thenReturn(new File("/임시경로", "이미지.png"));
 
         final AuthToken generate = authTokenGenerator.generate(player.getMember(), 1L, AuthType.KAKAO);
         final String accessToken = generate.getAccessToken();
 
-        //when
+        final CreatePlaceRequest createPlaceRequest = new CreatePlaceRequest("루터회관",
+                                                                             "이곳은 역사와 전통이 깊은 루터회관입니다.",
+                                                                             1.234,
+                                                                             5.6789,
+                                                                             "image/url",
+                                                                             player.getId(),
+                                                                             1L);
+
+        // when
         final ExtractableResponse<Response> extract = given()
                 .log().all()
-                .multiPart(new MultiPartSpecBuilder(place.getName()).controlName("name").charset(StandardCharsets.UTF_8).build())
-                .multiPart(new MultiPartSpecBuilder(place.getDescription()).controlName("description").charset(StandardCharsets.UTF_8).build())
-                .multiPart(
-                        new MultiPartSpecBuilder(place.getPosition().getLatitude().setScale(6, RoundingMode.HALF_DOWN).doubleValue()).controlName(
-                                "latitude").charset(StandardCharsets.UTF_8).build())
-                .multiPart(
-                        new MultiPartSpecBuilder(place.getPosition().getLongitude().setScale(6, RoundingMode.HALF_DOWN).doubleValue()).controlName(
-                                "longitude").charset(StandardCharsets.UTF_8).build())
-                .multiPart(new MultiPartSpecBuilder(new FileInputStream(new File("src/test/java/com/now/naaga/place/fixture/루터회관.png"))).controlName(
-                                                                                                                                                "imageFile").charset(StandardCharsets.UTF_8)
-                                                                                                                                        .fileName(
-                                                                                                                                                "src/test/java/com/now/naaga/place/fixture/루터회관.png")
-                                                                                                                                        .mimeType(
-                                                                                                                                                "image/png")
-                                                                                                                                        .build())
                 .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(createPlaceRequest)
                 .when()
                 .post("/places")
                 .then()
                 .log().all()
                 .extract();
-        final int statusCode = extract.statusCode();
-        final String location = extract.header("Location");
-        final PlaceResponse actual = extract.as(PlaceResponse.class);
-        final PlaceResponse expected = PlaceResponse.from(place);
 
-        //then
+        // then
+        final int statusCode = extract.statusCode();
+        final PlaceResponse actual = extract.as(PlaceResponse.class);
+        final Position position = Position.of(createPlaceRequest.latitude(),
+                                              createPlaceRequest.longitude());
+        final PlaceResponse expected = new PlaceResponse(getIdFromLocationHeader(extract),
+                                                         createPlaceRequest.name(),
+                                                         CoordinateResponse.from(position),
+                                                         createPlaceRequest.imageUrl(),
+                                                         createPlaceRequest.description());
         assertSoftly(softAssertions -> {
             softAssertions.assertThat(statusCode).isEqualTo(HttpStatus.CREATED.value());
-            softAssertions.assertThat(location).isEqualTo("/places/" + actual.id());
-            softAssertions.assertThat(expected)
+            softAssertions.assertThat(actual)
                           .usingRecursiveComparison()
-                          .ignoringFields("id", "imageUrl")
-                          .isEqualTo(actual);
-        });
-
-    }
-
-    @Test
-    void 장소_추가_요청_시_주변_20미터_내에_이미_등록된_목적지가_있다면_예외를_응답한다() throws FileNotFoundException {
-        //given
-        final Player player = playerBuilder.init()
-                                           .build();
-
-        placeBuilder.init()
-                    .registeredPlayer(player)
-                    .position(서울_좌표)
-                    .build();
-
-        final Place seoulPlace = PLACE();
-
-        final AuthToken generate = authTokenGenerator.generate(player.getMember(), 1L, AuthType.KAKAO);
-        final String accessToken = generate.getAccessToken();
-
-        //when
-        final ExtractableResponse<Response> extract = given()
-                .log().all()
-                .multiPart(new MultiPartSpecBuilder(seoulPlace.getName()).controlName("name").charset(StandardCharsets.UTF_8).build())
-                .multiPart(new MultiPartSpecBuilder(seoulPlace.getDescription()).controlName("description").charset(StandardCharsets.UTF_8).build())
-                .multiPart(
-                        new MultiPartSpecBuilder(seoulPlace.getPosition().getLatitude().setScale(6, RoundingMode.HALF_DOWN).doubleValue()).controlName("latitude").charset(StandardCharsets.UTF_8)
-                                                                                                                                          .build())
-                .multiPart(
-                        new MultiPartSpecBuilder(seoulPlace.getPosition().getLongitude().setScale(6, RoundingMode.HALF_DOWN).doubleValue()).controlName("longitude").charset(StandardCharsets.UTF_8)
-                                                                                                                                           .build())
-                .multiPart(new MultiPartSpecBuilder(new FileInputStream(new File("src/test/java/com/now/naaga/place/fixture/루터회관.png"))).controlName("imageFile").charset(StandardCharsets.UTF_8)
-                                                                                                                                        .fileName("src/test/java/com/now/naaga/place/fixture/루터회관.png")
-                                                                                                                                        .mimeType("image/png").build())
-                .header("Authorization", "Bearer " + accessToken)
-                .when()
-                .post("/places")
-                .then()
-                .log().all()
-                .extract();
-        final int statusCode = extract.statusCode();
-        final ExceptionResponse actual = extract.as(ExceptionResponse.class);
-        PlaceExceptionType exceptionType = PlaceExceptionType.ALREADY_EXIST_NEARBY;
-        ExceptionResponse expected = new ExceptionResponse(exceptionType.errorCode(), exceptionType.errorMessage());
-
-        //then
-        assertSoftly(softAssertions -> {
-            softAssertions.assertThat(statusCode).isEqualTo(HttpStatus.BAD_REQUEST.value());
-            softAssertions.assertThat(expected)
-                          .usingRecursiveComparison()
-                          .isEqualTo(actual);
+                          .isEqualTo(expected);
         });
     }
+
+    // TODO: 2023/10/03 장소 검수 API 구현 이후 삭제 예정
+//    @Test
+//    void 장소_추가_요청_시_주변_20미터_내에_이미_등록된_목적지가_있다면_예외를_응답한다() throws FileNotFoundException {
+//        //given
+//        final Player player = playerBuilder.init()
+//                                           .build();
+//
+//        placeBuilder.init()
+//                    .registeredPlayer(player)
+//                    .position(서울_좌표)
+//                    .build();
+//
+//        final Place seoulPlace = PLACE();
+//
+//        final AuthToken generate = authTokenGenerator.generate(player.getMember(), 1L, AuthType.KAKAO);
+//        final String accessToken = generate.getAccessToken();
+//
+//        //when
+//        final ExtractableResponse<Response> extract = given()
+//                .log().all()
+//                .multiPart(new MultiPartSpecBuilder(seoulPlace.getName()).controlName("name").charset(StandardCharsets.UTF_8).build())
+//                .multiPart(new MultiPartSpecBuilder(seoulPlace.getDescription()).controlName("description").charset(StandardCharsets.UTF_8).build())
+//                .multiPart(
+//                        new MultiPartSpecBuilder(seoulPlace.getPosition().getLatitude().setScale(6, RoundingMode.HALF_DOWN).doubleValue()).controlName("latitude").charset(StandardCharsets.UTF_8)
+//                                                                                                                                          .build())
+//                .multiPart(
+//                        new MultiPartSpecBuilder(seoulPlace.getPosition().getLongitude().setScale(6, RoundingMode.HALF_DOWN).doubleValue()).controlName("longitude").charset(StandardCharsets.UTF_8)
+//                                                                                                                                           .build())
+//                .multiPart(new MultiPartSpecBuilder(new FileInputStream(new File("src/test/java/com/now/naaga/place/fixture/루터회관.png"))).controlName("imageFile").charset(StandardCharsets.UTF_8)
+//                                                                                                                                        .fileName("src/test/java/com/now/naaga/place/fixture/루터회관.png")
+//                                                                                                                                        .mimeType("image/png").build())
+//                .header("Authorization", "Bearer " + accessToken)
+//                .when()
+//                .post("/places")
+//                .then()
+//                .log().all()
+//                .extract();
+//        final int statusCode = extract.statusCode();
+//        final ExceptionResponse actual = extract.as(ExceptionResponse.class);
+//        PlaceExceptionType exceptionType = PlaceExceptionType.ALREADY_EXIST_NEARBY;
+//        ExceptionResponse expected = new ExceptionResponse(exceptionType.errorCode(), exceptionType.errorMessage());
+//
+//        //then
+//        assertSoftly(softAssertions -> {
+//            softAssertions.assertThat(statusCode).isEqualTo(HttpStatus.BAD_REQUEST.value());
+//            softAssertions.assertThat(expected)
+//                          .usingRecursiveComparison()
+//                          .isEqualTo(actual);
+//        });
+//    }
 
     @Test
     void 장소를_아이디로_조회한다() {


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #376 

## 🛠️ 작업 내용
- [x] 장소 등록 허가 API 설계 및 구현

## 🎯 리뷰 포인트
관리자 페이지에서 사용할 검수 장소 등록 허가 API 를 구현하였습니다!

먼저, 대부분의 장소 API 엔드포인트는 사용자가 주체이지만, 등록 허가에 대한 API 는 사용자가 아닌 관리자가 주체입니다.

여기서 중요한 점은, `사용자가 주체인 API 의 인가 장치는 jwt 토큰 방식`이지만, `관리자가 주체인 API 의 인가 장치는 basic 인증 방식`입니다.

따라서, 같은 엔드포인트에 대해서 서로 다른 HTTP 메서드에 따라 인터셉터도 달라져야 했습니다.

이 부분에 대한 기술적 해결 방안은 [루카 박사님의 논문](https://github.com/woowacourse-teams/2023-naaga/pull/374) 을 통해 확인하실 수 있고, 이를 이용해 서로 다른 인터셉터를 타도록 설정해두었습니다.

또한, 결정된 서비스 비즈니스 시나리오에 의하면, 관리자 페이지에서 등록 허가 버튼을 눌렀을 때 `인게임 장소에 데이터 등록 + 검수 장소에서 데이터 삭제` 라는 행위가 한번에 이루어져야합니다.

따라서 이를 구현하기 위해 하나의 트랜잭션으로 묶어 처리했습니다.

+)
ManagerAuthInterceptor 에서 Base64 디코딩하는 과정에서 로직 오류가 있어서, 이 부분을 함께 수정했습니다.

또한, 아직 검수 장소 삭제에 대한 로직이 구현되지 않은 관계로, 임시적으로 동작하지 않는 메서드를 구현해놓았습니다. 양해 부탁드립니다!

## ⏳ 작업 시간
추정 시간:   4시간
실제 시간:   4시간
