### PR TITLE
feat: 앱 강제 업데이트 기능 구현

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -105,6 +105,7 @@ dependencies {
     implementation(platform('com.google.firebase:firebase-bom:32.2.0'))
     implementation "com.google.firebase:firebase-analytics-ktx"
     implementation("com.google.firebase:firebase-crashlytics-ktx")
+    implementation("com.google.firebase:firebase-config-ktx")
 
     // kakao Login
     implementation "com.kakao.sdk:v2-user:2.15.0"

--- a/android/app/src/main/java/com/now/naaga/common/dialog/ConfirmDialog.kt
+++ b/android/app/src/main/java/com/now/naaga/common/dialog/ConfirmDialog.kt
@@ -1,4 +1,4 @@
-package com.now.naaga.util.dialog
+package com.now.naaga.common.dialog
 
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -29,7 +29,7 @@ import com.now.naaga.presentation.adventureresult.AdventureResultActivity
 import com.now.naaga.presentation.uimodel.mapper.toDomain
 import com.now.naaga.presentation.uimodel.mapper.toUi
 import com.now.naaga.presentation.uimodel.model.AdventureUiModel
-import com.now.naaga.util.getParcelableCompat
+import com.now.naaga.util.extension.getParcelableCompat
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
@@ -9,12 +9,12 @@ import com.google.firebase.ktx.Firebase
 import com.google.firebase.remoteconfig.ktx.remoteConfig
 import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
 import com.now.naaga.R
+import com.now.naaga.common.dialog.ConfirmDialog
 import com.now.naaga.data.firebase.analytics.AnalyticsDelegate
 import com.now.naaga.data.firebase.analytics.DefaultAnalyticsDelegate
 import com.now.naaga.data.firebase.analytics.SPLASH_MY_PAGE_STATISTICS
 import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import com.now.naaga.presentation.login.LoginActivity
-import com.now.naaga.util.dialog.ConfirmDialog
 import com.now.naaga.util.extension.getPackageInfoCompat
 import dagger.hilt.android.AndroidEntryPoint
 

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
@@ -43,7 +43,7 @@ class SplashActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
             if (it.isSuccessful) {
                 val minVersion = remoteConfig.getString(MIN_VERSION)
                 if (minVersion > curVersion) {
-                    showConfirmDialog()
+                    showUpdateDialog()
                 } else {
                     viewModel.testTokenValid()
                 }
@@ -51,7 +51,7 @@ class SplashActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
         }
     }
 
-    private fun showConfirmDialog() {
+    private fun showUpdateDialog() {
         ConfirmDialog.Builder().build(
             title = getString(R.string.confirm_dialog_title),
             description = getString(R.string.confirm_dialog_description),

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
@@ -1,14 +1,21 @@
 package com.now.naaga.presentation.splash
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.remoteconfig.ktx.remoteConfig
+import com.google.firebase.remoteconfig.ktx.remoteConfigSettings
 import com.now.naaga.R
 import com.now.naaga.data.firebase.analytics.AnalyticsDelegate
 import com.now.naaga.data.firebase.analytics.DefaultAnalyticsDelegate
 import com.now.naaga.data.firebase.analytics.SPLASH_MY_PAGE_STATISTICS
 import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import com.now.naaga.presentation.login.LoginActivity
+import com.now.naaga.util.dialog.ConfirmDialog
+import com.now.naaga.util.extension.getPackageInfoCompat
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -18,9 +25,48 @@ class SplashActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         registerAnalytics(this.lifecycle)
-        viewModel.testTokenValid()
+        updateCheck()
         subscribe()
         setContentView(R.layout.activity_splash)
+    }
+
+    private fun updateCheck() {
+        val remoteConfig = Firebase.remoteConfig
+        val configSettings = remoteConfigSettings {
+            minimumFetchIntervalInSeconds = 3600
+        }
+        remoteConfig.setConfigSettingsAsync(configSettings)
+        remoteConfig.setDefaultsAsync(mapOf(MIN_VERSION to DEFAULT_VERSION))
+        val curVersion = packageManager.getPackageInfoCompat(packageName).versionName
+
+        remoteConfig.fetchAndActivate().addOnCompleteListener {
+            if (it.isSuccessful) {
+                val minVersion = remoteConfig.getString(MIN_VERSION)
+                if (minVersion > curVersion) {
+                    showConfirmDialog()
+                } else {
+                    viewModel.testTokenValid()
+                }
+            }
+        }
+    }
+
+    private fun showConfirmDialog() {
+        ConfirmDialog.Builder().build(
+            title = getString(R.string.confirm_dialog_title),
+            description = getString(R.string.confirm_dialog_description),
+            positiveText = getString(R.string.confirm_dialog_positive_text),
+            negativeText = getString(R.string.confirm_dialog_negative_text),
+            positiveAction = ::navigateToPlayStore,
+            negativeAction = ::finish,
+        ).show(supportFragmentManager, TAG_CONFIRM_DIALOG)
+    }
+
+    private fun navigateToPlayStore() {
+        val uri = PLAY_STORE_URI + packageName
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
+        startActivity(intent)
+        finish()
     }
 
     private fun subscribe() {
@@ -44,5 +90,12 @@ class SplashActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
     private fun startLoginActivity() {
         startActivity(LoginActivity.getIntent(this))
         finish()
+    }
+
+    companion object {
+        const val TAG_CONFIRM_DIALOG = "CONFIRM"
+        const val MIN_VERSION = "version"
+        const val PLAY_STORE_URI = "market://details?id="
+        const val DEFAULT_VERSION = "0.0.0"
     }
 }

--- a/android/app/src/main/java/com/now/naaga/util/dialog/ConfirmDialog.kt
+++ b/android/app/src/main/java/com/now/naaga/util/dialog/ConfirmDialog.kt
@@ -1,0 +1,91 @@
+package com.now.naaga.util.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.now.naaga.databinding.DialogConfirmBinding
+import com.now.naaga.util.getWidthProportionalToDevice
+
+class ConfirmDialog private constructor() : DialogFragment() {
+    private var _binding: DialogConfirmBinding? = null
+    private val binding: DialogConfirmBinding
+        get() = requireNotNull(_binding) { BINDING_NULL_ERROR }
+    private var title: String? = null
+    private var description: String? = null
+    private var positiveText: String? = null
+    private var negativeText: String? = null
+    private lateinit var positiveAction: () -> Unit
+    private lateinit var negativeAction: () -> Unit
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        _binding = DialogConfirmBinding.inflate(layoutInflater)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setSize()
+        setBackgroundTransparent()
+        setTitle()
+        setDescription()
+        setPositiveText()
+        setNegativeText()
+        binding.tvConfirmDialogPositive.setOnClickListener { positiveAction(); dismiss() }
+        binding.tvConfirmDialogNegative.setOnClickListener { negativeAction(); dismiss() }
+        isCancelable = false
+    }
+
+    private fun setSize() {
+        val dialogWidth = getWidthProportionalToDevice(requireContext(), WIDTH_RATE)
+        dialog?.window?.setLayout(dialogWidth, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    private fun setBackgroundTransparent() {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+    }
+
+    private fun setTitle() {
+        binding.tvConfirmDialogTitle.text = title
+    }
+
+    private fun setDescription() {
+        binding.tvConfirmDialogDescription.text = description
+    }
+
+    private fun setPositiveText() {
+        binding.tvConfirmDialogPositive.text = positiveText
+    }
+
+    private fun setNegativeText() {
+        binding.tvConfirmDialogNegative.text = negativeText
+    }
+
+    class Builder {
+        fun build(
+            title: String,
+            description: String,
+            positiveText: String,
+            negativeText: String,
+            positiveAction: () -> Unit,
+            negativeAction: () -> Unit,
+        ): ConfirmDialog {
+            return ConfirmDialog().apply {
+                this.title = title
+                this.description = description
+                this.positiveText = positiveText
+                this.negativeText = negativeText
+                this.positiveAction = positiveAction
+                this.negativeAction = negativeAction
+            }
+        }
+    }
+
+    companion object {
+        private const val WIDTH_RATE = 0.9f
+        private const val BINDING_NULL_ERROR = "ConfirmDialog에서 바인딩 초기화 에러가 발생했습니다."
+    }
+}

--- a/android/app/src/main/java/com/now/naaga/util/extension/IntentExt.kt
+++ b/android/app/src/main/java/com/now/naaga/util/extension/IntentExt.kt
@@ -1,4 +1,4 @@
-package com.now.naaga.util
+package com.now.naaga.util.extension
 
 import android.content.Intent
 import android.os.Build

--- a/android/app/src/main/java/com/now/naaga/util/extension/PackageManagerExt.kt
+++ b/android/app/src/main/java/com/now/naaga/util/extension/PackageManagerExt.kt
@@ -1,0 +1,14 @@
+package com.now.naaga.util.extension
+
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+
+fun PackageManager.getPackageInfoCompat(packageName: String, flags: Int = 0): PackageInfo {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(flags.toLong()))
+    } else {
+        @Suppress("DEPRECATION")
+        getPackageInfo(packageName, flags)
+    }
+}

--- a/android/app/src/main/res/layout/dialog_confirm.xml
+++ b/android/app/src/main/res/layout/dialog_confirm.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/rect_radius_small"
+        android:backgroundTint="@color/white">
+
+        <TextView
+            android:id="@+id/tv_confirm_dialog_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:textColor="@color/black"
+            android:textSize="18sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@string/confirm_dialog_title" />
+
+        <TextView
+            android:id="@+id/tv_confirm_dialog_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textColor="@color/light_gray"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_confirm_dialog_title"
+            tools:text="@string/confirm_dialog_description" />
+
+        <TextView
+            android:id="@+id/tv_confirm_dialog_positive"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp"
+            android:background="@drawable/rect_radius_small_bottom_left"
+            android:backgroundTint="@color/main_dark_blue"
+            android:gravity="center"
+            android:paddingVertical="20dp"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/tv_confirm_dialog_negative"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_confirm_dialog_description"
+            tools:text="@string/confirm_dialog_positive_text" />
+
+        <TextView
+            android:id="@+id/tv_confirm_dialog_negative"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:background="@drawable/rect_radius_small_bottom_right"
+            android:backgroundTint="@color/light_gray"
+            android:gravity="center"
+            android:paddingVertical="20dp"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_confirm_dialog_positive"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tv_confirm_dialog_positive"
+            app:layout_constraintTop_toTopOf="@+id/tv_confirm_dialog_positive"
+            tools:text="@string/confirm_dialog_negative_text" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/app/src/main/res/layout/dialog_confirm.xml
+++ b/android/app/src/main/res/layout/dialog_confirm.xml
@@ -15,7 +15,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="40dp"
             android:textColor="@color/black"
-            android:textSize="18sp"
+            android:textSize="24sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"

--- a/android/app/src/main/res/layout/dialog_confirm.xml
+++ b/android/app/src/main/res/layout/dialog_confirm.xml
@@ -26,6 +26,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
+            android:gravity="center"
             android:textColor="@color/light_gray"
             android:textSize="12sp"
             app:layout_constraintEnd_toEndOf="parent"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -68,7 +68,7 @@
     <string name="rank_title">Leader Board</string>
     <string name="rank_my_rank">%d등</string>
 
-    <!-- mypage -->
+    <!-- MyPageActivity -->
     <string name="mypage_adventure_record">모험 기록</string>
     <string name="mypage_rank">%d등</string>
     <string name="mypage_percentage">(상위%d%%)</string>
@@ -85,13 +85,13 @@
     <string name="mypage_empty_item_title">My Places</string>
     <string name="mypage_empty_description">추가한 장소가 없어요!\n장소를 추가해 주세요!</string>
 
-    <!--give up dialog-->
+    <!--GiveUpDialog-->
     <string name="give_up_dialog_title">게임을 포기하시겠어요?</string>
     <string name="give_up_dialog_description">지금 떠나면 점수가 하락해요</string>
     <string name="give_up_dialog_continue">이어 하기</string>
     <string name="give_up_dialog_give_up">포기 하기</string>
 
-    <!--hint using dialog-->
+    <!--HintUsingDialog-->
     <string name="hint_using_dialog_title">힌트를 사용하시겠어요?</string>
     <string name="hint_using_dialog_description">힌트가 %d개 남았어요</string>
     <string name="hint_using_dialog_continue">힌트 받기</string>
@@ -112,15 +112,21 @@
     <string name="setting_expiration_error_message">"인증 정보가 만료 되었어요!"</string>
     <string name="setting_logout_message">로그아웃 되었습니다.</string>
 
-    <!-- Withdrawal Dialog -->
+    <!-- WithdrawalDialog -->
     <string name="withdrawal_dialog_title">정말 회원 탈퇴를 하시겠습니까?</string>
     <string name="withdrawal_dialog_description">나아가와 함께 즐거운 모험을 계속해보세요!</string>
     <string name="withdrawal_dialog_positive">네</string>
     <string name="withdrawal_dialog_negative">아니요</string>
 
-    <!--logout dialog-->
+    <!-- LogoutDialog -->
     <string name="logout_dialog_title">정말 로그아웃을 하시겠습니까?</string>
     <string name="logout_dialog_description">나아가와 함께 즐거운 모험을 계속해보세요!</string>
     <string name="logout_dialog_positive_text">아니오</string>
     <string name="logout_dialog_negative_text">예</string>
+
+    <!-- ConfirmDialog -->
+    <string name="confirm_dialog_title">업데이트 확인</string>
+    <string name="confirm_dialog_description">새로운 버전이 출시되었어요!\n업데이트가 필요해요!</string>
+    <string name="confirm_dialog_positive_text">업데이트</string>
+    <string name="confirm_dialog_negative_text">취소</string>
 </resources>


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #370 

## 🛠️ 작업 내용
앱 강제 업데이트 기능 구현
- [x] Firebase config를 통해 업데이트가 필요한 versionName 받아오기
- [x] 받아온 versionName보다 현재 실행하는 versionName이 낮으면 업데이트 요청하기

## 🎯 리뷰 포인트
### Firebase Config
- Firebase Config를 통해서 업데이트가 필요한 버전 이하인 경우 버전 업데이트를 요청하도록 구현했어요!  
- 다음과 같이 Firebase에 우리가 원하는 값들을 저장해둘 수 있습니다.
![image](https://github.com/woowacourse-teams/2023-naaga/assets/84285337/9fa48ffa-0e1b-4caf-a3e9-754af090ee7c)
- 앱에서는 splash 화면에서 Firebase Config에 올라가있는 version과 현재 앱의 version을 비교하여 현재 앱의 버전이 더 낮은 경우 업데이트를 요청하는 다이얼로그가 뜨도록 구현했어요!
- fetchAndActivate() 메서드가 비동기적으로 동작하기 때문에 스플래시 화면이 오래 뜰 수도 있다는 단점이 있습니다.
- 갱신 주기를 3600초(1시간)으로 설정해두었기 때문에 접속한지 1시간 내에 강제 업데이트가 필요한 내용이 플레이 스토어에 업데이트가 된다면 이것도 문제가 될 수도 있을 것 같긴 해요.

### 확장함수
- 현재 앱의 versionName을 받아오는 기능을 PackageManager 의 확장함수로 정의했습니다. 이렇게 한 이유는 버전에 따른 분기가 필요한 코드라서 그렇습니다.
- 현재 util 패키지가 꾕장히 너저분하더라고요. 그래서 패키지 정리가 필요해보이지만 현재 pr에서 작업할 것은 아니라고 생각해서 그냥 뒀습니다... 

### ConfirmDialog
- 인게임에서 사용하는 다이얼로그와는 다른 확인용 다이얼로그를 만들었어요. 크게 다른 것은 없지만 업데이트를 강제 해야 할 때는 다이얼로그가 Cancelable하지 않도록 만들기 위해 추가했습니다.
- 버튼 2개의 비율이 1:1 입니다.
- 만들고나니 그냥 있던 다이얼로그의 이름을 조금 수정하고 사용했어도 되었겠다는 생각이 들었지만, 이미 만든거 리뷰어에게 의견을 물어보고 결정하자는 생각이 들어서 추가해두었습니다. 아마 이 다이얼로그를 회원탈퇴, 로그아웃 등에서도 사용할 수 있을 것 같아요
- 뽀또는 원래있던 다이얼로그를 재사용하는 것이 좋아보이나요? 아니면 이 다이얼로그가 있어도 될 것 같나요? 편하게 의견을 공유해주세요!

## ⏳ 작업 시간
추정 시간: 3h  
실제 시간: 3h  