### PR TITLE
feat: 검수 중인 장소에 대한 등록 승인 거절 API 구현

### DIFF
--- a/backend/src/main/java/com/now/naaga/common/config/WebConfig.java
+++ b/backend/src/main/java/com/now/naaga/common/config/WebConfig.java
@@ -57,12 +57,14 @@ public class WebConfig implements WebMvcConfigurer {
                 .excludeRequestPattern("/**/*.ico")
                 .excludeRequestPattern("/ranks")
                 .excludeRequestPattern("/**", HttpMethod.OPTIONS)
-                .excludeRequestPattern("/places", HttpMethod.POST);
+                .excludeRequestPattern("/places", HttpMethod.POST)
+                .excludeRequestPattern("/temporary-places/**", HttpMethod.DELETE);
     }
 
     private HandlerInterceptor mapManagerAuthInterceptor() {
         return new RequestMatcherInterceptor(managerAuthInterceptor)
-                .includeRequestPattern("/places", HttpMethod.POST);
+                .includeRequestPattern("/places", HttpMethod.POST)
+                .includeRequestPattern("/temporary-places/**", HttpMethod.DELETE);
     }
 
     @Override

--- a/backend/src/main/java/com/now/naaga/place/presentation/PlaceController.java
+++ b/backend/src/main/java/com/now/naaga/place/presentation/PlaceController.java
@@ -63,4 +63,17 @@ public class PlaceController {
                 .location(URI.create("/places/" + place.getId()))
                 .body(response);
     }
+
+// TODO: 2023/10/03 장소 검수 API 구현 이후 삭제 예정
+//    @PostMapping
+//    public ResponseEntity<PlaceResponse> createPlace(@Auth final PlayerRequest playerRequest,
+//                                                     @ModelAttribute final CreatePlaceRequest createPlaceRequest) {
+//        CreatePlaceCommand createPlaceCommand = CreatePlaceCommand.of(playerRequest, createPlaceRequest);
+//        final Place savedPlace = placeService.createPlace(createPlaceCommand);
+//        final PlaceResponse response = PlaceResponse.from(savedPlace);
+//        return ResponseEntity
+//                .status(HttpStatus.CREATED)
+//                .location(URI.create("/places/" + savedPlace.getId()))
+//                .body(response);
+//    }
 }

--- a/backend/src/main/java/com/now/naaga/temporaryplace/application/TemporaryPlaceService.java
+++ b/backend/src/main/java/com/now/naaga/temporaryplace/application/TemporaryPlaceService.java
@@ -1,5 +1,6 @@
 package com.now.naaga.temporaryplace.application;
 
+import com.now.naaga.temporaryplace.repository.TemporaryPlaceRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,7 +8,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class TemporaryPlaceService {
 
+    private final TemporaryPlaceRepository temporaryPlaceRepository;
+
+    public TemporaryPlaceService(final TemporaryPlaceRepository temporaryPlaceRepository) {
+        this.temporaryPlaceRepository = temporaryPlaceRepository;
+    }
+
     public void deleteById(final Long id) {
-        return;
+        temporaryPlaceRepository.deleteById(id);
     }
 }

--- a/backend/src/main/java/com/now/naaga/temporaryplace/domain/TemporaryPlace.java
+++ b/backend/src/main/java/com/now/naaga/temporaryplace/domain/TemporaryPlace.java
@@ -5,6 +5,7 @@ import com.now.naaga.place.domain.Position;
 import com.now.naaga.player.domain.Player;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,7 +29,7 @@ public class TemporaryPlace extends BaseEntity {
 
     private String imageUrl;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "player_id")
     private Player registeredPlayer;
 

--- a/backend/src/main/java/com/now/naaga/temporaryplace/presentation/TemporaryPlaceController.java
+++ b/backend/src/main/java/com/now/naaga/temporaryplace/presentation/TemporaryPlaceController.java
@@ -1,9 +1,28 @@
 package com.now.naaga.temporaryplace.presentation;
 
+import com.now.naaga.temporaryplace.application.TemporaryPlaceService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/temporary-places")
 @RestController
 public class TemporaryPlaceController {
+
+    private final TemporaryPlaceService temporaryPlaceService;
+
+    public TemporaryPlaceController(final TemporaryPlaceService temporaryPlaceService) {
+        this.temporaryPlaceService = temporaryPlaceService;
+    }
+
+    @DeleteMapping("/{temporaryPlaceId}")
+    public ResponseEntity<Void> deleteTemporaryPlace(@PathVariable final Long temporaryPlaceId) {
+        temporaryPlaceService.deleteById(temporaryPlaceId);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
 }

--- a/backend/src/test/java/com/now/naaga/common/builder/TemporaryPlaceBuilder.java
+++ b/backend/src/test/java/com/now/naaga/common/builder/TemporaryPlaceBuilder.java
@@ -1,0 +1,79 @@
+package com.now.naaga.common.builder;
+
+import static com.now.naaga.common.fixture.PlaceFixture.DESCRIPTION;
+import static com.now.naaga.common.fixture.PlaceFixture.IMAGE_URL;
+import static com.now.naaga.common.fixture.PlaceFixture.NAME;
+import static com.now.naaga.common.fixture.PositionFixture.잠실역_교보문고_좌표;
+
+import com.now.naaga.place.domain.Position;
+import com.now.naaga.player.domain.Player;
+import com.now.naaga.temporaryplace.domain.TemporaryPlace;
+import com.now.naaga.temporaryplace.repository.TemporaryPlaceRepository;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TemporaryPlaceBuilder {
+
+    @Autowired
+    private TemporaryPlaceRepository temporaryPlaceRepository;
+
+    @Autowired
+    private PlayerBuilder playerBuilder;
+
+    private String name;
+
+    private String description;
+
+    private Position position;
+
+    private String imageUrl;
+
+    private Optional<Player> registeredPlayer;
+
+    public TemporaryPlaceBuilder init() {
+        this.name = NAME;
+        this.description = DESCRIPTION;
+        this.position = 잠실역_교보문고_좌표;
+        this.imageUrl = IMAGE_URL;
+        this.registeredPlayer = Optional.empty();
+        return this;
+    }
+
+    public TemporaryPlaceBuilder name(final String name) {
+        this.name = name;
+        return this;
+    }
+
+    public TemporaryPlaceBuilder description(final String description) {
+        this.description = description;
+        return this;
+    }
+
+    public TemporaryPlaceBuilder position(final Position position) {
+        this.position = position;
+        return this;
+    }
+
+    public TemporaryPlaceBuilder imageUrl(final String imageUrl) {
+        this.imageUrl = imageUrl;
+        return this;
+    }
+
+    public TemporaryPlaceBuilder registeredPlayer(final Player persistedPlayer) {
+        this.registeredPlayer = Optional.ofNullable(persistedPlayer);
+        return this;
+    }
+
+    public TemporaryPlace build() {
+        final Player persistedPlayer = registeredPlayer.orElseGet(this::getPersistedPlayer);
+        final TemporaryPlace temporaryPlace = new TemporaryPlace(name, description, position, imageUrl, persistedPlayer);
+        return temporaryPlaceRepository.save(temporaryPlace);
+    }
+
+    private Player getPersistedPlayer() {
+        return playerBuilder.init()
+                            .build();
+    }
+}

--- a/backend/src/test/java/com/now/naaga/temporaryplace/application/TemporaryPlaceServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/temporaryplace/application/TemporaryPlaceServiceTest.java
@@ -1,17 +1,15 @@
 package com.now.naaga.temporaryplace.application;
 
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import com.now.naaga.common.builder.TemporaryPlaceBuilder;
+import com.now.naaga.temporaryplace.domain.TemporaryPlace;
 import com.now.naaga.temporaryplace.repository.TemporaryPlaceRepository;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -22,21 +20,30 @@ import org.springframework.test.context.jdbc.Sql;
 @SpringBootTest
 class TemporaryPlaceServiceTest {
 
-    @MockBean
+    @Autowired
     private TemporaryPlaceRepository temporaryPlaceRepository;
 
     @Autowired
     private TemporaryPlaceService temporaryPlaceService;
 
+    @Autowired
+    private TemporaryPlaceBuilder temporaryPlaceBuilder;
+
     @Test
     void ID로_검수_장소_데이터를_삭제한다() {
         // given
-        doNothing().when(temporaryPlaceRepository).deleteById(anyLong());
+        final TemporaryPlace temporaryPlace = temporaryPlaceBuilder.init()
+                                                                   .build();
+
+        final Long id = temporaryPlace.getId();
 
         // when
-        temporaryPlaceService.deleteById(1L);
+        temporaryPlaceService.deleteById(id);
 
         // then
-        verify(temporaryPlaceRepository, times(1)).deleteById(1L);
+        final TemporaryPlace actual = temporaryPlaceRepository.findById(id)
+                                                              .orElse(null);
+
+        assertThat(actual).isNull();
     }
 }

--- a/backend/src/test/java/com/now/naaga/temporaryplace/application/TemporaryPlaceServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/temporaryplace/application/TemporaryPlaceServiceTest.java
@@ -1,0 +1,42 @@
+package com.now.naaga.temporaryplace.application;
+
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.now.naaga.temporaryplace.repository.TemporaryPlaceRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Sql("/truncate.sql")
+@ActiveProfiles("test")
+@SpringBootTest
+class TemporaryPlaceServiceTest {
+
+    @MockBean
+    private TemporaryPlaceRepository temporaryPlaceRepository;
+
+    @Autowired
+    private TemporaryPlaceService temporaryPlaceService;
+
+    @Test
+    void ID로_검수_장소_데이터를_삭제한다() {
+        // given
+        doNothing().when(temporaryPlaceRepository).deleteById(anyLong());
+
+        // when
+        temporaryPlaceService.deleteById(1L);
+
+        // then
+        verify(temporaryPlaceRepository, times(1)).deleteById(1L);
+    }
+}

--- a/backend/src/test/java/com/now/naaga/temporaryplace/presentation/TemporaryPlaceControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/temporaryplace/presentation/TemporaryPlaceControllerTest.java
@@ -1,0 +1,59 @@
+package com.now.naaga.temporaryplace.presentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.now.naaga.common.CommonControllerTest;
+import com.now.naaga.common.builder.TemporaryPlaceBuilder;
+import com.now.naaga.temporaryplace.domain.TemporaryPlace;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ActiveProfiles("test")
+class TemporaryPlaceControllerTest extends CommonControllerTest {
+
+    @Autowired
+    private TemporaryPlaceBuilder temporaryPlaceBuilder;
+
+    @Value("${manager.id}")
+    private String id;
+
+    @Value("${manager.password}")
+    private String password;
+
+    @BeforeEach
+    protected void setUp() {
+        super.setUp();
+    }
+
+    @Test
+    void ID를_통한_삭제_요청이_성공하면_204_응답코드를_반환한다() {
+        // given
+        final TemporaryPlace temporaryPlace = temporaryPlaceBuilder.init()
+                                                                   .build();
+
+        // when
+        final ExtractableResponse<Response> extract = RestAssured.given()
+                                                                 .log().all()
+                                                                 .auth().preemptive().basic(id, password)
+                                                                 .when()
+                                                                 .delete("/temporary-places/{temporaryPlaceId}", temporaryPlace.getId())
+                                                                 .then()
+                                                                 .log().all()
+                                                                 .extract();
+
+        // then
+        final int statusCode = extract.statusCode();
+        assertThat(statusCode).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #388 

## 🛠️ 작업 내용
- [x] 검수 장소에 대한 삭제 API 구현

## 🎯 리뷰 포인트
[이 PR](https://github.com/woowacourse-teams/2023-naaga/pull/398) 에 대한 연장선인 작업물입니다.

따라서, PR의 내용에 대한 맥락은 위 PR 과 같습니다. 참고해주세요!

관리자 페이지에서 사용할 승인 거절은 결국 DB 단에서의 단순 삭제 로직이라서, 크게 어려운 점은 없었던 것 같습니다.

그나마 고민했던 지점은, 검수 장소 삭제에 대해 soft delete 할 것인지, hard delete 할 것인지였는데요!

검수 장소 엔티티가 복잡한 연관관계를 가지는 것도 아니고, 검수 승인 거절을 하였는데 DB 단에 굳이 남겨서 리소스를 낭비할 필요는 없을 것 같아 hard delete 로 구현하게 되었습니다!

+)

# [작업 커밋 범위](https://github.com/woowacourse-teams/2023-naaga/pull/401/files/23814c18af6365d808a192fdfdd8d821f5768c6d..6581ef9d65cc16e409b179770cfbe07790455131)

이전 PR 브랜치에 리베이스해서 작업했더니, 커밋 내역이 같이 딸려와서 위에 커밋 범위를 남겨놓겠습니다!!

참고해서 리뷰해주시면 감사하겠습니다 😁

## ⏳ 작업 시간
추정 시간:   2시간
실제 시간:   2시간
