### PR TITLE
feat: 게임 입장 시 사진이 먼저 뜨는 기능 구현

### DIFF
--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -99,6 +99,7 @@ class OnAdventureActivity :
         viewModel.hints.observe(this) { hints ->
             drawHintMarkers(hints)
             binding.lottieOnAdventureLoading.visibility = View.GONE
+            showPolaroidDialog()
         }
         viewModel.lastHint.observe(this) {
             drawHintMarkers(listOf(it))


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #405

## 🛠️ 작업 내용
- [x] 게임 입장 시 사진이 먼저 뜨는 기능 구현

## 🎯 리뷰 포인트
```kotlin
viewModel.hints.observe(this) { hints ->
    drawHintMarkers(hints)
    binding.lottieOnAdventureLoading.visibility = View.GONE
    showPolaroidDialog()
}
```
- 힌트 마커들을 띄워주고, 로티를 보이지 않도록 한 다음 바로 사진 다이얼로그가 보이도록 했습니다! (실행해보면 조오오오금 어색한 감이 있긴 합니다..)

- 게임에 처음 입장할 때, 다시 입장할 때 모두 사진이 먼저 뜹니다. 재입장 시에도 매번 뜨도록 할 것인가는 논의해봐야 할 수도 있을 것 같아요. 저는 게임에 재입장 하는 경우가 흔하지 않을 것이라고 생각해서 괜찮다는 입장입니다! 생각이 어떤지 남겨주시면 좋을 것 같아요🙃

### 다이얼로그 <a href="#다이얼로그" id="다이얼로그">#</a>
- 우리가 사용하는 다이얼로그들을 common/dialog package 하위로 이동하는 것은 어떤가요? 현재 PR과는 관련이 없다고 생각해서 의견만 남겨봅니다!
- 추가로 이름을 수정하면 더 좋을 것 같아요! 아래는 제 생각입니다.
    - NaagaAlertDialog -> GameDialog (인게임에서만 사용)
    - PolaroidDialog 유지 (인게임에서만 사용)
    - ConfirmDialog 유지 (인게임 외에서 범용적으로 사용)
    - LocationPermissionDialog(begin, upload 에서 사용), CameraPermissionDialog(upload에서만 사용) 두 개를  PermissionDialog 로 합쳐 사용하기
        - 우리가 요청하는 Permission을 enum class로 만들고 PermissionDialog의 생성 인자로 원하는 Permission을 넘겨주면 내부적으로 이미지를 변경하도록 하는 것을 생각했어요!
- 추가로 현재 인게임에서 사용하는 다이얼로그는 빅스가 수정할 것이라고 생각해서 로직만 넣었습니다!

## ⏳ 작업 시간
추정 시간: 1h  
실제 시간: 30m  