### PR TITLE
hotfix: 액세스 토큰 리프레시 및 자동 로그인 로직 수정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.now.naaga"
         minSdk 28
         targetSdk 33
-        versionCode 5
-        versionName "1.1.0"
+        versionCode 6
+        versionName "1.1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunner "com.now.naaga.HiltTestRunner"

--- a/android/app/src/main/java/com/now/naaga/data/local/DefaultAuthDataSource.kt
+++ b/android/app/src/main/java/com/now/naaga/data/local/DefaultAuthDataSource.kt
@@ -28,8 +28,7 @@ class DefaultAuthDataSource(context: Context) : AuthDataSource {
     }
 
     override fun getRefreshToken(): String? {
-        val refreshToken = authPreference.getString(REFRESH_TOKEN, null) ?: return null
-        return BEARER + refreshToken
+        return authPreference.getString(REFRESH_TOKEN, null)
     }
 
     override fun setRefreshToken(newToken: String) {

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/AuthInterceptor.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/AuthInterceptor.kt
@@ -17,6 +17,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import okhttp3.internal.closeQuietly
 import org.json.JSONObject
 
 class AuthInterceptor : Interceptor {
@@ -31,6 +32,7 @@ class AuthInterceptor : Interceptor {
 
         if (response.code == 401) {
             val newAccessToken = getRefreshedToken(accessToken).getOrElse { return response }
+            response.closeQuietly()
             return chain.proceed(chain.request().newBuilder().addHeader(AUTH_KEY, newAccessToken).build())
         }
         return response
@@ -98,8 +100,7 @@ class AuthInterceptor : Interceptor {
         const val AUTH_KEY = "Authorization"
         const val AUTH_REFRESH_KEY = "refreshToken"
 
-        const val AUTH_PATH = "auth"
-        const val AUTH_REFRESH_PATH = "auth/refresh"
+        const val AUTH_REFRESH_PATH = "/auth/refresh"
 
         const val NO_REFRESH_TOKEN = "리프레시 토큰이 없습니다"
         const val REFRESH_FAILURE = "토큰 리프레시 실패"


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #434 

## 🛠️ 작업 내용
액세스 토큰 리프레시 및 자동 로그인 로직 수정
- [x] local.properties 에 다른 BASE_URL 사용으로 인해 URL이 달라짐
- [x] refreshToken 에는 "Bearer: " 이 붙지 않음
- [x] Interceptor에서 response를 close 해주지 않음

## 🎯 리뷰 포인트
### local.properties
- local.properties 에 등록한 BASE_URL을 마지막에 **"/" 로 끝나도록 통일시켜 주세요.**
- 이를 기반으로 모든 URL은 "/"로 시작하도록 통일하겠습니다. ex) /auth/refresh

### 버전 코드, 버전 이름
- 앱의 버전 코드를 6으로, 버전 이름을 "1.1.1" 로 변경하였습니다. 앱이 플레이스토어에 성공적으로 배포된다면 Firebase Remote Config에 등록된 강제 업데이트 요청 최소 버전도 "1.1.1"로 변경해줘야 합니다.

### http 상태코드가 401인 경우 분기처리
- AuthInterceptor의 intercept 에서 response.code(http 상태코드)가 401인 경우 서버에서 내려주는 에러코드가 101인 경우, 102인 경우를 다음과 같이 다르기 때문에 분기처리를 진행하려고 했습니다.
    - 101인 경우는 토큰 값이 잘못된 것이기 때문에 사용자에게 새로운 로그인을 요청해야 합니다. 
    - 102인 경우는 액세스 토큰이 만료된 것이기 때문에 액세스 리프레시 요청을 해야 합니다.
- 하지만 Response를 한 번 DTO로 변환하게 되면 해당 Response는 Closed 되게 됩니다. 즉, 아예 사용하지 못하는 상태로 된다는 것입니다.  때문에 서버에서 내려주는 에러코드에 따라 분기처리를 진행하지 않았습니다. 
- 401에러에 대해 리프레시 요청을 진행하고, 다시 실패한 경우 에러코드가 101인 경우 AuthorizationThrowable으로 변환하여 요청에 대한 응답을 실패로 반환하기 때문에 문제가 없으리라 생각됩니다.
- 하여 조금 더 좋은 코드로 개선하는 것은 조금 뒤로 미뤄두고 정상 동작이 가능한 상태를 유지하도록 했습니다. 어떻게 수정하면 좋을지 추후 논의해보면 좋을 것 같아요.

## ⏳ 작업 시간
추정 시간:   
실제 시간: 8h  

이유: 제가 짠 코드가 아니기도 하고, 당시 제가 업로드 및 위치 권한에 사로잡혀 로그인 로직에 관여를 못했던 것 같습니다. 그래서 빅스의 코드를 이해하는데 시간을 썼고, 백엔드 팀원과 함께 로깅 확인, 디버깅을 하며 어떤 요청에 대해 어떤 에러를 보여주는지 확인해보며 많은 로직을 테스트 해보느라 시간을 많이 쓰게 되었네요. 많은 시간을 투자했지만 거대한 문제를 해결한 것이 아니라 화가 잔뜩 나긴 했지만 해결했다는 생각에 기분은 좋습니다 :)

+추가로 구두로 언급했던 정리에 관한 것은 내일 주중에 해당 PR에 추가하도록 하겠습니다.