### PR TITLE
hotfix: 액세스 토큰 리프레시 로직 수정

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,8 @@ android {
         applicationId "com.now.naaga"
         minSdk 28
         targetSdk 33
-        versionCode 6
-        versionName "1.1.1"
+        versionCode 8
+        versionName "1.1.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunner "com.now.naaga.HiltTestRunner"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,7 +20,7 @@ android {
         applicationId "com.now.naaga"
         minSdk 28
         targetSdk 33
-        versionCode 8
+        versionCode 9
         versionName "1.1.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/AuthInterceptor.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/AuthInterceptor.kt
@@ -31,14 +31,14 @@ class AuthInterceptor : Interceptor {
         val response: Response = chain.proceed(headerAddedRequest)
 
         if (response.code == 401) {
-            val newAccessToken = getRefreshedToken(accessToken).getOrElse { return response }
+            val newAccessToken = getAccessTokenAfterRefresh(accessToken).getOrElse { return response }
             response.closeQuietly()
             return chain.proceed(chain.request().newBuilder().addHeader(AUTH_KEY, newAccessToken).build())
         }
         return response
     }
 
-    private fun getRefreshedToken(accessToken: String): Result<String> {
+    private fun getAccessTokenAfterRefresh(accessToken: String): Result<String> {
         val requestBody = createRefreshRequestBody()
         val request = createRefreshRequest(requestBody, accessToken)
 
@@ -46,7 +46,7 @@ class AuthInterceptor : Interceptor {
             return Result.failure(it)
         }
         storeToken(auth.accessToken, auth.refreshToken)
-        return Result.success(auth.accessToken)
+        return Result.success(BEARER + auth.accessToken)
     }
 
     private fun createRefreshRequestBody(): RequestBody {
@@ -97,12 +97,14 @@ class AuthInterceptor : Interceptor {
     }
 
     companion object {
-        const val AUTH_KEY = "Authorization"
-        const val AUTH_REFRESH_KEY = "refreshToken"
+        private const val AUTH_KEY = "Authorization"
+        private const val AUTH_REFRESH_KEY = "refreshToken"
 
-        const val AUTH_REFRESH_PATH = "/auth/refresh"
+        private const val AUTH_REFRESH_PATH = "/auth/refresh"
 
-        const val NO_REFRESH_TOKEN = "리프레시 토큰이 없습니다"
-        const val REFRESH_FAILURE = "토큰 리프레시 실패"
+        private const val BEARER = "Bearer "
+
+        private const val NO_REFRESH_TOKEN = "리프레시 토큰이 없습니다"
+        private const val REFRESH_FAILURE = "토큰 리프레시 실패"
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #445 

## 🛠️ 작업 내용
- [x] 액세스 토큰 리프레시 로직 수정

## 🎯 리뷰 포인트
### Refresh
```kotlin
private fun getAccessTokenAfterRefresh(accessToken: String): Result<String> {
    val requestBody = createRefreshRequestBody()
    val request = createRefreshRequest(requestBody, accessToken)

    val auth: NaagaAuthDto = requestRefresh(request).getOrElse {
        return Result.failure(it)
    }
    storeToken(auth.accessToken, auth.refreshToken)
    return Result.success(BEARER + auth.accessToken)
}
```
- 함수명을 조금 더 직관적으로 변경했습니다.
- 리프레시 토큰을 통해 액세스 토큰을 갱신하고, "Bearer " 를 붙여 반환하도록 변경했습니다.

## ⏳ 작업 시간
추정 시간:   
실제 시간: 3h  