### PR TITLE
feat: 쪽지 단건 조회 api 구현

### DIFF
--- a/backend/src/main/java/com/now/naaga/game/exception/GameExceptionType.java
+++ b/backend/src/main/java/com/now/naaga/game/exception/GameExceptionType.java
@@ -64,6 +64,12 @@ public enum GameExceptionType implements BaseExceptionType {
             HttpStatus.BAD_REQUEST,
             "시도 횟수를 이미 다 사용한 게임입니다"
     ),
+
+    NOT_EXIST_IN_PROGRESS(
+            414,
+            HttpStatus.NOT_FOUND,
+            "진행 중인 게임이 존재하지 않습니다."
+    ),
     ;
 
     private final int errorCode;

--- a/backend/src/main/java/com/now/naaga/game/exception/GameExceptionType.java
+++ b/backend/src/main/java/com/now/naaga/game/exception/GameExceptionType.java
@@ -29,6 +29,12 @@ public enum GameExceptionType implements BaseExceptionType {
             "배정 할 목적지가 존재하지 않습니다."
     ),
 
+    NOT_EXIST_IN_PROGRESS(
+            414,
+            HttpStatus.NOT_FOUND,
+            "진행 중인 게임이 존재하지 않습니다."
+    ),
+
     NOT_ARRIVED(
             415,
             HttpStatus.BAD_REQUEST,
@@ -63,12 +69,6 @@ public enum GameExceptionType implements BaseExceptionType {
             418,
             HttpStatus.BAD_REQUEST,
             "시도 횟수를 이미 다 사용한 게임입니다"
-    ),
-
-    NOT_EXIST_IN_PROGRESS(
-            414,
-            HttpStatus.NOT_FOUND,
-            "진행 중인 게임이 존재하지 않습니다."
     ),
     ;
 

--- a/backend/src/main/java/com/now/naaga/game/exception/GameExceptionType.java
+++ b/backend/src/main/java/com/now/naaga/game/exception/GameExceptionType.java
@@ -53,6 +53,12 @@ public enum GameExceptionType implements BaseExceptionType {
             "아직 종료되지 않은 게임입니다."
     ),
 
+    NOT_REMAIN_ATTEMPTS(
+            418,
+            HttpStatus.BAD_REQUEST,
+            "시도 횟수를 이미 다 사용한 게임입니다"
+    ),
+
     HINT_NOT_EXIST_IN_GAME(
             454,
             HttpStatus.NOT_FOUND,
@@ -63,12 +69,6 @@ public enum GameExceptionType implements BaseExceptionType {
             455,
             HttpStatus.BAD_REQUEST,
             "사용할 수 있는 힌트를 모두 소진했습니다."
-    ),
-
-    NOT_REMAIN_ATTEMPTS(
-            418,
-            HttpStatus.BAD_REQUEST,
-            "시도 횟수를 이미 다 사용한 게임입니다"
     ),
     ;
 

--- a/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
@@ -1,6 +1,5 @@
 package com.now.naaga.letter.application;
 
-import com.now.naaga.game.application.GameService;
 import com.now.naaga.letter.application.letterlog.ReadLetterLogService;
 import com.now.naaga.letter.application.letterlog.dto.LetterLogCreateCommand;
 import com.now.naaga.letter.domain.Letter;
@@ -19,7 +18,9 @@ import static com.now.naaga.letter.exception.LetterExceptionType.NO_EXIST;
 public class LetterService {
 
     private final LetterRepository letterRepository;
+
     private final ReadLetterLogService readLetterLogService;
+
     private final PlayerService playerService;
 
     public LetterService(final LetterRepository letterRepository,

--- a/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
@@ -39,7 +39,6 @@ public class LetterService {
         this.playerService = playerService;
     }
 
-    @Transactional
     public Letter findLetter(final LetterReadCommand letterReadCommand) {
         final Player player = playerService.findPlayerById(letterReadCommand.playerId());
         final Letter foundLetter = findLetterById(letterReadCommand.letterId());

--- a/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
@@ -1,0 +1,67 @@
+package com.now.naaga.letter.application;
+
+import com.now.naaga.game.application.GameService;
+import com.now.naaga.game.application.dto.FindGameByStatusCommand;
+import com.now.naaga.game.domain.Game;
+import com.now.naaga.game.exception.GameException;
+import com.now.naaga.game.exception.GameExceptionType;
+import com.now.naaga.letter.application.letterlog.ReadLetterLogService;
+import com.now.naaga.letter.application.letterlog.dto.LetterLogCreateCommand;
+import com.now.naaga.letter.domain.Letter;
+import com.now.naaga.letter.exception.LetterException;
+import com.now.naaga.letter.presentation.dto.LetterReadCommand;
+import com.now.naaga.letter.repository.LetterRepository;
+import com.now.naaga.player.application.PlayerService;
+import com.now.naaga.player.domain.Player;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.now.naaga.game.domain.GameStatus.IN_PROGRESS;
+import static com.now.naaga.letter.exception.LetterExceptionType.NO_EXIST;
+
+@Transactional
+@Service
+public class LetterService {
+
+    private final LetterRepository letterRepository;
+    private final ReadLetterLogService readLetterLogService;
+    private final GameService gameService;
+    private final PlayerService playerService;
+
+    public LetterService(final LetterRepository letterRepository,
+                         final ReadLetterLogService readLetterLogService,
+                         final GameService gameService, final PlayerService playerService) {
+        this.letterRepository = letterRepository;
+        this.readLetterLogService = readLetterLogService;
+        this.gameService = gameService;
+        this.playerService = playerService;
+    }
+
+    @Transactional(readOnly = true)
+    public Letter findLetterById(final LetterReadCommand letterReadCommand) {
+        final Player player = playerService.findPlayerById(letterReadCommand.playerId());
+        final Letter foundLetter = findLetterById2(letterReadCommand.letterId());
+
+        final Game gameInProgress = getGameInProgress(player);
+        final LetterLogCreateCommand letterLogCreateCommand = new LetterLogCreateCommand(gameInProgress, foundLetter);
+        readLetterLogService.log(letterLogCreateCommand);
+        return foundLetter;
+    }
+
+    @Transactional(readOnly = true)
+    public Letter findLetterById2(final Long id) {
+        return letterRepository.findById(id)
+                .orElseThrow(() -> new LetterException(NO_EXIST));
+    }
+
+    private Game getGameInProgress(final Player player) {
+        final FindGameByStatusCommand findGameByStatusCommand = new FindGameByStatusCommand(player.getId(), IN_PROGRESS);
+        final List<Game> gamesInProgress = gameService.findGamesByStatus(findGameByStatusCommand);
+        if (gamesInProgress.isEmpty()) {
+            throw new GameException(GameExceptionType.NOT_EXIST_IN_PROGRESS);
+        }
+        return gamesInProgress.get(0);
+    }
+}

--- a/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
@@ -39,7 +39,7 @@ public class LetterService {
         this.playerService = playerService;
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public Letter findLetter(final LetterReadCommand letterReadCommand) {
         final Player player = playerService.findPlayerById(letterReadCommand.playerId());
         final Letter foundLetter = findLetterById(letterReadCommand.letterId());

--- a/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
@@ -20,28 +20,22 @@ public class LetterService {
 
     private final LetterRepository letterRepository;
     private final ReadLetterLogService readLetterLogService;
-    private final GameService gameService;
     private final PlayerService playerService;
 
     public LetterService(final LetterRepository letterRepository,
                          final ReadLetterLogService readLetterLogService,
-                         final GameService gameService, final PlayerService playerService) {
+                         final PlayerService playerService) {
         this.letterRepository = letterRepository;
         this.readLetterLogService = readLetterLogService;
-        this.gameService = gameService;
         this.playerService = playerService;
     }
 
     public Letter findLetter(final LetterReadCommand letterReadCommand) {
         final Player player = playerService.findPlayerById(letterReadCommand.playerId());
-        final Letter foundLetter = findLetterById(letterReadCommand.letterId());
+        final Letter foundLetter = letterRepository.findById(letterReadCommand.letterId())
+                .orElseThrow(() -> new LetterException(NO_EXIST));
+
         readLetterLogService.log(new LetterLogCreateCommand(player.getId(), foundLetter));
         return foundLetter;
-    }
-
-    @Transactional(readOnly = true)
-    public Letter findLetterById(final Long id) {
-        return letterRepository.findById(id)
-                .orElseThrow(() -> new LetterException(NO_EXIST));
     }
 }

--- a/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
@@ -1,10 +1,6 @@
 package com.now.naaga.letter.application;
 
 import com.now.naaga.game.application.GameService;
-import com.now.naaga.game.application.dto.FindGameByStatusCommand;
-import com.now.naaga.game.domain.Game;
-import com.now.naaga.game.exception.GameException;
-import com.now.naaga.game.exception.GameExceptionType;
 import com.now.naaga.letter.application.letterlog.ReadLetterLogService;
 import com.now.naaga.letter.application.letterlog.dto.LetterLogCreateCommand;
 import com.now.naaga.letter.domain.Letter;
@@ -16,9 +12,6 @@ import com.now.naaga.player.domain.Player;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
-import static com.now.naaga.game.domain.GameStatus.IN_PROGRESS;
 import static com.now.naaga.letter.exception.LetterExceptionType.NO_EXIST;
 
 @Transactional
@@ -42,9 +35,7 @@ public class LetterService {
     public Letter findLetter(final LetterReadCommand letterReadCommand) {
         final Player player = playerService.findPlayerById(letterReadCommand.playerId());
         final Letter foundLetter = findLetterById(letterReadCommand.letterId());
-        final Game gameInProgress = getGameInProgress(player);
-        final LetterLogCreateCommand letterLogCreateCommand = new LetterLogCreateCommand(gameInProgress, foundLetter);
-        readLetterLogService.log(letterLogCreateCommand);
+        readLetterLogService.log(new LetterLogCreateCommand(player.getId(), foundLetter));
         return foundLetter;
     }
 
@@ -52,14 +43,5 @@ public class LetterService {
     public Letter findLetterById(final Long id) {
         return letterRepository.findById(id)
                 .orElseThrow(() -> new LetterException(NO_EXIST));
-    }
-
-    private Game getGameInProgress(final Player player) {
-        final FindGameByStatusCommand findGameByStatusCommand = new FindGameByStatusCommand(player.getId(), IN_PROGRESS);
-        final List<Game> gamesInProgress = gameService.findGamesByStatus(findGameByStatusCommand);
-        if (gamesInProgress.isEmpty()) {
-            throw new GameException(GameExceptionType.NOT_EXIST_IN_PROGRESS);
-        }
-        return gamesInProgress.get(0);
     }
 }

--- a/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/LetterService.java
@@ -40,10 +40,9 @@ public class LetterService {
     }
 
     @Transactional(readOnly = true)
-    public Letter findLetterById(final LetterReadCommand letterReadCommand) {
+    public Letter findLetter(final LetterReadCommand letterReadCommand) {
         final Player player = playerService.findPlayerById(letterReadCommand.playerId());
-        final Letter foundLetter = findLetterById2(letterReadCommand.letterId());
-
+        final Letter foundLetter = findLetterById(letterReadCommand.letterId());
         final Game gameInProgress = getGameInProgress(player);
         final LetterLogCreateCommand letterLogCreateCommand = new LetterLogCreateCommand(gameInProgress, foundLetter);
         readLetterLogService.log(letterLogCreateCommand);
@@ -51,7 +50,7 @@ public class LetterService {
     }
 
     @Transactional(readOnly = true)
-    public Letter findLetterById2(final Long id) {
+    public Letter findLetterById(final Long id) {
         return letterRepository.findById(id)
                 .orElseThrow(() -> new LetterException(NO_EXIST));
     }

--- a/backend/src/main/java/com/now/naaga/letter/application/letterlog/ReadLetterLogService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/letterlog/ReadLetterLogService.java
@@ -1,24 +1,45 @@
 package com.now.naaga.letter.application.letterlog;
 
+import com.now.naaga.game.application.GameService;
+import com.now.naaga.game.application.dto.FindGameByStatusCommand;
+import com.now.naaga.game.domain.Game;
+import com.now.naaga.game.exception.GameException;
+import com.now.naaga.game.exception.GameExceptionType;
 import com.now.naaga.letter.application.letterlog.dto.LetterLogCreateCommand;
 import com.now.naaga.letter.domain.letterlog.ReadLetterLog;
 import com.now.naaga.letter.repository.letterlog.ReadLetterLogRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+import static com.now.naaga.game.domain.GameStatus.IN_PROGRESS;
+
 @Transactional
 @Service
 public class ReadLetterLogService {
 
+    private final GameService gameService;
     private final ReadLetterLogRepository readLetterLogRepository;
 
-    public ReadLetterLogService(final ReadLetterLogRepository readLetterLogRepository) {
+    public ReadLetterLogService(final GameService gameService,
+                                final ReadLetterLogRepository readLetterLogRepository) {
+        this.gameService = gameService;
         this.readLetterLogRepository = readLetterLogRepository;
     }
 
     public void log(final LetterLogCreateCommand letterLogCreateCommand) {
-        final ReadLetterLog readLetterLog = new ReadLetterLog(letterLogCreateCommand.game(),
-                letterLogCreateCommand.letter());
+        final Game gameInProgress = getGameInProgress(letterLogCreateCommand.playerId());
+        final ReadLetterLog readLetterLog = new ReadLetterLog(gameInProgress, letterLogCreateCommand.letter());
         readLetterLogRepository.save(readLetterLog);
+    }
+
+    private Game getGameInProgress(final Long playerId) {
+        final FindGameByStatusCommand findGameByStatusCommand = new FindGameByStatusCommand(playerId, IN_PROGRESS);
+        final List<Game> gamesInProgress = gameService.findGamesByStatus(findGameByStatusCommand);
+        if (gamesInProgress.isEmpty()) {
+            throw new GameException(GameExceptionType.NOT_EXIST_IN_PROGRESS);
+        }
+        return gamesInProgress.get(0);
     }
 }

--- a/backend/src/main/java/com/now/naaga/letter/application/letterlog/ReadLetterLogService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/letterlog/ReadLetterLogService.java
@@ -20,6 +20,7 @@ import static com.now.naaga.game.domain.GameStatus.IN_PROGRESS;
 public class ReadLetterLogService {
 
     private final GameService gameService;
+
     private final ReadLetterLogRepository readLetterLogRepository;
 
     public ReadLetterLogService(final GameService gameService,

--- a/backend/src/main/java/com/now/naaga/letter/application/letterlog/ReadLetterLogService.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/letterlog/ReadLetterLogService.java
@@ -1,0 +1,24 @@
+package com.now.naaga.letter.application.letterlog;
+
+import com.now.naaga.letter.application.letterlog.dto.LetterLogCreateCommand;
+import com.now.naaga.letter.domain.letterlog.ReadLetterLog;
+import com.now.naaga.letter.repository.letterlog.ReadLetterLogRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class ReadLetterLogService {
+
+    private final ReadLetterLogRepository readLetterLogRepository;
+
+    public ReadLetterLogService(final ReadLetterLogRepository readLetterLogRepository) {
+        this.readLetterLogRepository = readLetterLogRepository;
+    }
+
+    public void log(final LetterLogCreateCommand letterLogCreateCommand) {
+        final ReadLetterLog readLetterLog = new ReadLetterLog(letterLogCreateCommand.game(),
+                letterLogCreateCommand.letter());
+        readLetterLogRepository.save(readLetterLog);
+    }
+}

--- a/backend/src/main/java/com/now/naaga/letter/application/letterlog/dto/LetterLogCreateCommand.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/letterlog/dto/LetterLogCreateCommand.java
@@ -1,0 +1,8 @@
+package com.now.naaga.letter.application.letterlog.dto;
+
+import com.now.naaga.game.domain.Game;
+import com.now.naaga.letter.domain.Letter;
+
+public record LetterLogCreateCommand(Game game,
+                                     Letter letter) {
+}

--- a/backend/src/main/java/com/now/naaga/letter/application/letterlog/dto/LetterLogCreateCommand.java
+++ b/backend/src/main/java/com/now/naaga/letter/application/letterlog/dto/LetterLogCreateCommand.java
@@ -1,8 +1,7 @@
 package com.now.naaga.letter.application.letterlog.dto;
 
-import com.now.naaga.game.domain.Game;
 import com.now.naaga.letter.domain.Letter;
 
-public record LetterLogCreateCommand(Game game,
+public record LetterLogCreateCommand(Long playerId,
                                      Letter letter) {
 }

--- a/backend/src/main/java/com/now/naaga/letter/exception/LetterException.java
+++ b/backend/src/main/java/com/now/naaga/letter/exception/LetterException.java
@@ -1,0 +1,18 @@
+package com.now.naaga.letter.exception;
+
+import com.now.naaga.common.exception.BaseException;
+import com.now.naaga.common.exception.BaseExceptionType;
+
+public class LetterException extends BaseException {
+
+    private final LetterExceptionType letterExceptionType;
+
+    public LetterException(final LetterExceptionType letterExceptionType) {
+        this.letterExceptionType = letterExceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return letterExceptionType;
+    }
+}

--- a/backend/src/main/java/com/now/naaga/letter/exception/LetterExceptionType.java
+++ b/backend/src/main/java/com/now/naaga/letter/exception/LetterExceptionType.java
@@ -1,0 +1,41 @@
+package com.now.naaga.letter.exception;
+
+import com.now.naaga.common.exception.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum LetterExceptionType implements BaseExceptionType {
+
+    NO_EXIST(
+            604,
+            HttpStatus.NOT_FOUND,
+            "해당 쪽지가 존재하지 않습니다."
+    ),
+    ;
+
+    private final int errorCode;
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    LetterExceptionType(final int errorCode,
+                        final HttpStatus httpStatus,
+                        final String errorMessage) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public int errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/backend/src/main/java/com/now/naaga/letter/presentation/LetterController.java
+++ b/backend/src/main/java/com/now/naaga/letter/presentation/LetterController.java
@@ -27,7 +27,7 @@ public class LetterController {
     public ResponseEntity<LetterResponse> findLetterById(@Auth final PlayerRequest playerRequest,
                                                          @PathVariable final Long letterId) {
         final LetterReadCommand letterReadCommand = LetterReadCommand.of(playerRequest, letterId);
-        final Letter letter = letterService.findLetterById(letterReadCommand);
+        final Letter letter = letterService.findLetter(letterReadCommand);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(LetterResponse.from(letter));

--- a/backend/src/main/java/com/now/naaga/letter/presentation/LetterController.java
+++ b/backend/src/main/java/com/now/naaga/letter/presentation/LetterController.java
@@ -1,9 +1,35 @@
 package com.now.naaga.letter.presentation;
 
+import com.now.naaga.auth.presentation.annotation.Auth;
+import com.now.naaga.letter.application.LetterService;
+import com.now.naaga.letter.domain.Letter;
+import com.now.naaga.letter.presentation.dto.LetterReadCommand;
+import com.now.naaga.letter.presentation.dto.LetterResponse;
+import com.now.naaga.player.presentation.dto.PlayerRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/letters")
 @RestController
 public class LetterController {
+
+    private final LetterService letterService;
+
+    public LetterController(final LetterService letterService) {
+        this.letterService = letterService;
+    }
+
+    @GetMapping("/{letterId}")
+    public ResponseEntity<LetterResponse> findLetterById(@Auth final PlayerRequest playerRequest,
+                                                         @PathVariable final Long letterId) {
+        final LetterReadCommand letterReadCommand = LetterReadCommand.of(playerRequest, letterId);
+        final Letter letter = letterService.findLetterById(letterReadCommand);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(LetterResponse.from(letter));
+    }
 }

--- a/backend/src/main/java/com/now/naaga/letter/presentation/dto/LetterReadCommand.java
+++ b/backend/src/main/java/com/now/naaga/letter/presentation/dto/LetterReadCommand.java
@@ -1,0 +1,13 @@
+package com.now.naaga.letter.presentation.dto;
+
+import com.now.naaga.player.presentation.dto.PlayerRequest;
+
+public record LetterReadCommand(Long playerId,
+                                Long letterId) {
+
+    public static LetterReadCommand of(final PlayerRequest playerRequest,
+                                       final Long letterId) {
+        final Long playerId = playerRequest.playerId();
+        return new LetterReadCommand(playerId, letterId);
+    }
+}

--- a/backend/src/main/java/com/now/naaga/letter/presentation/dto/LetterResponse.java
+++ b/backend/src/main/java/com/now/naaga/letter/presentation/dto/LetterResponse.java
@@ -1,0 +1,20 @@
+package com.now.naaga.letter.presentation.dto;
+
+import com.now.naaga.game.presentation.dto.CoordinateResponse;
+import com.now.naaga.letter.domain.Letter;
+import com.now.naaga.player.presentation.dto.PlayerResponse;
+
+public record LetterResponse(Long id,
+                             PlayerResponse player,
+                             CoordinateResponse coordinate,
+                             String message,
+                             String registerDate) {
+
+    public static LetterResponse from(final Letter letter) {
+        final Long id = letter.getId();
+        final PlayerResponse playerResponse = PlayerResponse.from(letter.getRegisteredPlayer());
+        final CoordinateResponse coordinateResponse = CoordinateResponse.of(letter.getPosition());
+        final String registerDate = letter.getCreatedTime().toString();
+        return new LetterResponse(id, playerResponse, coordinateResponse, letter.getMessage(), registerDate);
+    }
+}

--- a/backend/src/test/java/com/now/naaga/letter/application/LetterServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/letter/application/LetterServiceTest.java
@@ -1,0 +1,108 @@
+package com.now.naaga.letter.application;
+
+import com.now.naaga.common.builder.GameBuilder;
+import com.now.naaga.common.builder.LetterBuilder;
+import com.now.naaga.common.builder.PlaceBuilder;
+import com.now.naaga.common.builder.PlayerBuilder;
+import com.now.naaga.game.domain.Game;
+import com.now.naaga.letter.domain.Letter;
+import com.now.naaga.letter.exception.LetterException;
+import com.now.naaga.letter.presentation.dto.LetterReadCommand;
+import com.now.naaga.letter.repository.letterlog.ReadLetterLogRepository;
+import com.now.naaga.place.domain.Place;
+import com.now.naaga.player.domain.Player;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import static com.now.naaga.common.fixture.PositionFixture.잠실_루터회관_정문_좌표;
+import static com.now.naaga.common.fixture.PositionFixture.잠실역_교보문고_좌표;
+import static com.now.naaga.letter.exception.LetterExceptionType.NO_EXIST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Sql("/truncate.sql")
+@SpringBootTest
+class LetterServiceTest {
+
+    @Autowired
+    private LetterService letterService;
+
+    @Autowired
+    private ReadLetterLogRepository readLetterLogRepository;
+
+    @Autowired
+    private PlayerBuilder playerBuilder;
+
+    @Autowired
+    private PlaceBuilder placeBuilder;
+
+    @Autowired
+    private GameBuilder gameBuilder;
+
+    @Autowired
+    private LetterBuilder letterBuilder;
+
+    @Test
+    void 쪽지를_단건조회_한다() {
+        // given
+        final Player player = playerBuilder.init()
+                .build();
+
+        final Place destination = placeBuilder.init()
+                .position(잠실_루터회관_정문_좌표)
+                .build();
+
+        final Game game = gameBuilder.init()
+                .place(destination)
+                .player(player)
+                .startPosition(잠실역_교보문고_좌표)
+                .build();
+
+        final Player letterRegister = playerBuilder.init()
+                .build();
+
+        final Letter letter = letterBuilder.init()
+                .registeredPlayer(letterRegister)
+                .build();
+
+        // when
+        final Letter actual = letterService.findLetter(new LetterReadCommand(player.getId(), letter.getId()));
+
+        // then
+        assertThat(actual.getId()).isEqualTo(letter.getId());
+    }
+
+    @Test
+    void 쪽지가_존재하지_않으면_예외가_발생한다() {
+        // given & when
+        final Player player = playerBuilder.init()
+                .build();
+
+        final Place destination = placeBuilder.init()
+                .position(잠실_루터회관_정문_좌표)
+                .build();
+
+        final Game game = gameBuilder.init()
+                .place(destination)
+                .player(player)
+                .startPosition(잠실역_교보문고_좌표)
+                .build();
+
+        final Player letterRegister = playerBuilder.init()
+                .build();
+
+        final Letter letter = letterBuilder.init()
+                .registeredPlayer(letterRegister)
+                .build();
+
+        // then
+        final LetterException letterException = assertThrows(
+                LetterException.class, () -> letterService.findLetter(new LetterReadCommand(player.getId(), letter.getId() + 1)));
+        assertThat(letterException.exceptionType()).isEqualTo(NO_EXIST);
+    }
+}

--- a/backend/src/test/java/com/now/naaga/letter/application/letterlog/ReadLetterLogServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/letter/application/letterlog/ReadLetterLogServiceTest.java
@@ -1,0 +1,120 @@
+package com.now.naaga.letter.application.letterlog;
+
+import com.now.naaga.common.builder.GameBuilder;
+import com.now.naaga.common.builder.LetterBuilder;
+import com.now.naaga.common.builder.PlaceBuilder;
+import com.now.naaga.common.builder.PlayerBuilder;
+import com.now.naaga.game.domain.Game;
+import com.now.naaga.game.domain.GameStatus;
+import com.now.naaga.game.exception.GameException;
+import com.now.naaga.letter.application.letterlog.dto.LetterLogCreateCommand;
+import com.now.naaga.letter.domain.Letter;
+import com.now.naaga.letter.domain.letterlog.ReadLetterLog;
+import com.now.naaga.letter.repository.letterlog.ReadLetterLogRepository;
+import com.now.naaga.place.domain.Place;
+import com.now.naaga.player.domain.Player;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static com.now.naaga.common.fixture.PositionFixture.잠실_루터회관_정문_좌표;
+import static com.now.naaga.common.fixture.PositionFixture.잠실역_교보문고_좌표;
+import static com.now.naaga.game.exception.GameExceptionType.NOT_EXIST_IN_PROGRESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@Sql("/truncate.sql")
+@SpringBootTest
+class ReadLetterLogServiceTest {
+
+    @Autowired
+    private ReadLetterLogService readLetterLogService;
+
+    @Autowired
+    private ReadLetterLogRepository readLetterLogRepository;
+
+    @Autowired
+    private PlayerBuilder playerBuilder;
+
+    @Autowired
+    private PlaceBuilder placeBuilder;
+
+    @Autowired
+    private GameBuilder gameBuilder;
+
+    @Autowired
+    private LetterBuilder letterBuilder;
+
+    @Test
+    void 읽은쪽지로그에_데이터를_저장한다() {
+        // given
+        final Player player = playerBuilder.init()
+                .build();
+
+        final Place destination = placeBuilder.init()
+                .position(잠실_루터회관_정문_좌표)
+                .build();
+
+        final Game game = gameBuilder.init()
+                .place(destination)
+                .player(player)
+                .startPosition(잠실역_교보문고_좌표)
+                .build();
+
+        final Player letterRegister = playerBuilder.init()
+                .build();
+
+        final Letter letter = letterBuilder.init()
+                .registeredPlayer(letterRegister)
+                .build();
+
+        // when
+        readLetterLogService.log(new LetterLogCreateCommand(player.getId(), letter));
+
+        // then
+        final List<ReadLetterLog> actual = readLetterLogRepository.findAll();
+        final long expected = actual.get(0).getLetter().getId();
+
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(actual).hasSize(1);
+            softAssertions.assertThat(expected).isEqualTo(letter.getId());
+        });
+    }
+
+    @Test
+    void 읽은쪽지로그에_데이터저장시_진행중인_게임이없으면_예외가_발생한다() {
+        // given && when
+        final Player player = playerBuilder.init()
+                .build();
+
+        final Place destination = placeBuilder.init()
+                .position(잠실_루터회관_정문_좌표)
+                .build();
+
+        final Game game = gameBuilder.init()
+                .place(destination)
+                .player(player)
+                .startPosition(잠실역_교보문고_좌표)
+                .gameStatus(GameStatus.DONE)
+                .build();
+
+        final Player letterRegister = playerBuilder.init()
+                .build();
+
+        final Letter letter = letterBuilder.init()
+                .registeredPlayer(letterRegister)
+                .build();
+
+        //then
+        final GameException gameException = assertThrows(
+                GameException.class, () -> readLetterLogService.log(new LetterLogCreateCommand(player.getId(), letter)));
+        assertThat(gameException.exceptionType()).isEqualTo(NOT_EXIST_IN_PROGRESS);
+    }
+}

--- a/backend/src/test/java/com/now/naaga/letter/presentation/LetterControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/letter/presentation/LetterControllerTest.java
@@ -97,6 +97,7 @@ class LetterControllerTest extends CommonControllerTest {
             softAssertions.assertThat(actual)
                     .usingRecursiveComparison()
                     .ignoringExpectedNullFields()
+                    .ignoringFieldsOfTypes(LocalDateTime.class)
                     .isEqualTo(expected);
         });
     }

--- a/backend/src/test/java/com/now/naaga/letter/presentation/LetterControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/letter/presentation/LetterControllerTest.java
@@ -97,7 +97,7 @@ class LetterControllerTest extends CommonControllerTest {
             softAssertions.assertThat(actual)
                     .usingRecursiveComparison()
                     .ignoringExpectedNullFields()
-                    .ignoringFieldsOfTypes(LocalDateTime.class)
+                    .ignoringFields("registerDate")
                     .isEqualTo(expected);
         });
     }

--- a/backend/src/test/java/com/now/naaga/letter/presentation/LetterControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/letter/presentation/LetterControllerTest.java
@@ -1,0 +1,145 @@
+package com.now.naaga.letter.presentation;
+
+import com.now.naaga.auth.domain.AuthToken;
+import com.now.naaga.auth.infrastructure.AuthType;
+import com.now.naaga.auth.infrastructure.jwt.AuthTokenGenerator;
+import com.now.naaga.common.CommonControllerTest;
+import com.now.naaga.common.builder.*;
+import com.now.naaga.common.exception.ExceptionResponse;
+import com.now.naaga.game.domain.Game;
+import com.now.naaga.game.repository.GameRepository;
+import com.now.naaga.letter.domain.Letter;
+import com.now.naaga.letter.presentation.dto.LetterResponse;
+import com.now.naaga.place.domain.Place;
+import com.now.naaga.player.domain.Player;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+import static com.now.naaga.common.fixture.PositionFixture.잠실_루터회관_정문_좌표;
+import static com.now.naaga.common.fixture.PositionFixture.잠실역_교보문고_좌표;
+import static com.now.naaga.game.exception.GameExceptionType.NOT_EXIST_IN_PROGRESS;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LetterControllerTest extends CommonControllerTest {
+
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @Autowired
+    private GameBuilder gameBuilder;
+
+    @Autowired
+    private PlaceBuilder placeBuilder;
+
+    @Autowired
+    private PlayerBuilder playerBuilder;
+
+    @Autowired
+    private LetterBuilder letterBuilder;
+
+    @BeforeEach
+    protected void setUp() {
+        super.setUp();
+    }
+
+    @Test
+    void 쪽지_식별자로_쪽지를_조회한다() {
+        // given & when
+        final Player player = playerBuilder.init()
+                .build();
+
+        final Place destination = placeBuilder.init()
+                .position(잠실_루터회관_정문_좌표)
+                .build();
+
+        final Game game = gameBuilder.init()
+                .place(destination)
+                .player(player)
+                .startPosition(잠실역_교보문고_좌표)
+                .build();
+
+        final Letter letter = letterBuilder.init()
+                .position(잠실_루터회관_정문_좌표)
+                .build();
+
+        final AuthToken generate = authTokenGenerator.generate(player.getMember(), 1L, AuthType.KAKAO);
+        final String accessToken = generate.getAccessToken();
+
+        final ExtractableResponse<Response> extract = RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .get("/letters/{letterId}", letter.getId())
+                .then().log().all()
+                .extract();
+
+        // then
+        final int statusCode = extract.statusCode();
+        final LetterResponse actual = extract.as(LetterResponse.class);
+        final LetterResponse expected = LetterResponse.from(letter);
+
+        assertSoftly(softAssertions -> {
+            softAssertions.assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
+            softAssertions.assertThat(actual)
+                    .usingRecursiveComparison()
+                    .ignoringExpectedNullFields()
+                    .isEqualTo(expected);
+        });
+    }
+
+    @Test
+    void 쪽지_식별자로_쪽지를_조회시_잔행중_게임이_없으면_예외가_발생한다() {
+        // given & when
+        final Player player = playerBuilder.init()
+                .build();
+
+        final Place destination = placeBuilder.init()
+                .position(잠실_루터회관_정문_좌표)
+                .build();
+
+        final Letter letter = letterBuilder.init()
+                .position(잠실_루터회관_정문_좌표)
+                .build();
+
+        final AuthToken generate = authTokenGenerator.generate(player.getMember(), 1L, AuthType.KAKAO);
+        final String accessToken = generate.getAccessToken();
+
+        final ExtractableResponse<Response> extract = RestAssured
+                .given().log().all()
+                .header("Authorization", "Bearer " + accessToken)
+                .when()
+                .get("/letters/{letterId}", letter.getId())
+                .then().log().all()
+                .extract();
+
+        // then
+        final int statusCode = extract.statusCode();
+        final ExceptionResponse actual = extract.as(ExceptionResponse.class);
+
+        final ExceptionResponse expected = new ExceptionResponse(NOT_EXIST_IN_PROGRESS.errorCode(), NOT_EXIST_IN_PROGRESS.errorMessage());
+
+        assertSoftly(softAssertions -> {
+                    softAssertions.assertThat(statusCode).isEqualTo(HttpStatus.NOT_FOUND.value());
+                    softAssertions.assertThat(actual)
+                            .usingRecursiveComparison()
+                            .ignoringExpectedNullFields()
+                            .ignoringFieldsOfTypes(LocalDateTime.class)
+                            .isEqualTo(expected);
+                }
+        );
+    }
+}

--- a/backend/src/test/resources/truncate.sql
+++ b/backend/src/test/resources/truncate.sql
@@ -9,5 +9,7 @@ TRUNCATE TABLE game_result;
 TRUNCATE TABLE game;
 TRUNCATE TABLE hint;
 TRUNCATE TABLE auth_token;
+TRUNCATE TABLE letter;
+TRUNCATE TABLE read_letter_log;
 
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #459 

## 🛠️ 작업 내용
- [x] 쪽지 단건 조회 api구현

## 🎯 리뷰 포인트
흐름은 다음과 같습니다:
1. 쪽지 아이디로 쪽지를 찾는다.
2. 플레이어를 이용해서 진행중인 게임을 찾고, 찾은 쪽지id를 readLetterLog 테이블에 insert 한다.
3. 1번에서 찾은 쪽지를 반환한다.

고민사항:
NOT_EXIST_IN_PROGRESS("진행 중인 게임이 존재하지 않습니다.") 라는 에러가 추가되었습니다.
2번 과정에서 진행중인 게임을 찾는 로직이 있는데,
만약 진행중인 게임이 없다면 그건 잘못된 요청이며, 이를 NOT_EXIST("게임이 존재하지 않습니다.") 
라는 에러로 처리할지 NOT_EXIST_IN_PROGRESS 라는 새로운 에러가 필요할지 이레와 함께 논의한 결과
둘의 상황이 다르다고 판단하였습니다.
이유는 id로 조회할때 사용하는 NOT_EXIST 와 where 절을 사용하는 상황이 다르다고 생각하였습니다.
결론은 NOT_EXIST_IN_PROGRESS을 추가하게되었는데 다른 팀원들의 의견도 궁금하군요..!

인수테스트만 작성된 상태입니다. api 구현이 모두 끝나고 리뷰 받으면서 단위테스트를 추가하겠습니다..!
제가 마음이 급해서..양해 부탁합니다!


## ⏳ 작업 시간
추정 시간:   2h분
실제 시간:   2.5h분
