### PR TITLE
hotfix: 좋아요/싫어요 취소 시, 싫어요 취소해도 좋아요 통계 줄어드는 오류 수정

### DIFF
--- a/backend/src/main/java/com/now/naaga/like/application/PlaceLikeService.java
+++ b/backend/src/main/java/com/now/naaga/like/application/PlaceLikeService.java
@@ -2,6 +2,7 @@ package com.now.naaga.like.application;
 
 import com.now.naaga.like.application.dto.CancelLikeCommand;
 import com.now.naaga.like.domain.PlaceLike;
+import com.now.naaga.like.domain.PlaceLikeType;
 import com.now.naaga.like.exception.PlaceLikeException;
 import com.now.naaga.like.exception.PlaceLikeExceptionType;
 import com.now.naaga.like.repository.PlaceLikeRepository;
@@ -40,7 +41,13 @@ public class PlaceLikeService {
         final PlaceLike placeLike = maybePlaceLike.get();
         placeLikeRepository.delete(placeLike);
 
-        final SubtractLikeCommand subtractLikeCommand = new SubtractLikeCommand(placeId);
-        placeStatisticsService.subtractLike(subtractLikeCommand);
+        subtractPlaceLikeCount(placeId, placeLike);
+    }
+
+    private void subtractPlaceLikeCount(final Long placeId, final PlaceLike placeLike) {
+        if(placeLike.getType() == PlaceLikeType.LIKE) {
+            final SubtractLikeCommand subtractLikeCommand = new SubtractLikeCommand(placeId);
+            placeStatisticsService.subtractLike(subtractLikeCommand);
+        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #472 

## 🛠️ 작업 내용
PR에서 작업한 주요 내용을 적어주세요.
- [x] 좋아요/싫어요 취소 시, 싫어요 취소해도 좋아요 통계 줄어드는 오류 수정
- [x] 그에 대한 테스트

## 🎯 리뷰 포인트

hotfix입니다.

지난번 [좋아요/싫어요 삭제 PR](https://github.com/woowacourse-teams/2023-naaga/pull/433)에 대한 수정입니다.

좋아요를 삭제할 때만 좋아요 개수를 한개 줄여야되는데, 
싫어요를 삭제할 때도 좋아요 개수를 한개 줄이는 오류 수정입니다.

## ⏳ 작업 시간
추정 시간:  30분
실제 시간:   15분
