### PR TITLE
feat: query string이 필요한 API에서, query string이 없어도 예외를 발생시키지 않도록 수정

### DIFF
--- a/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
+++ b/backend/src/main/java/com/now/naaga/game/presentation/GameController.java
@@ -1,24 +1,40 @@
 package com.now.naaga.game.presentation;
 
+import static com.now.naaga.common.exception.CommonExceptionType.INVALID_REQUEST_PARAMETERS;
+
 import com.now.naaga.auth.presentation.annotation.Auth;
 import com.now.naaga.common.exception.CommonException;
 import com.now.naaga.game.application.GameService;
 import com.now.naaga.game.application.HintService;
-import com.now.naaga.game.application.dto.*;
+import com.now.naaga.game.application.dto.CreateGameCommand;
+import com.now.naaga.game.application.dto.CreateHintCommand;
+import com.now.naaga.game.application.dto.EndGameCommand;
+import com.now.naaga.game.application.dto.FindAllGamesCommand;
+import com.now.naaga.game.application.dto.FindGameByIdCommand;
+import com.now.naaga.game.application.dto.FindGameByStatusCommand;
+import com.now.naaga.game.application.dto.FindHintByIdCommand;
 import com.now.naaga.game.domain.Game;
 import com.now.naaga.game.domain.GameRecord;
 import com.now.naaga.game.domain.Hint;
-import com.now.naaga.game.presentation.dto.*;
+import com.now.naaga.game.presentation.dto.CoordinateRequest;
+import com.now.naaga.game.presentation.dto.EndGameRequest;
+import com.now.naaga.game.presentation.dto.GameResponse;
+import com.now.naaga.game.presentation.dto.GameResultResponse;
+import com.now.naaga.game.presentation.dto.GameStatusResponse;
+import com.now.naaga.game.presentation.dto.HintResponse;
 import com.now.naaga.player.presentation.dto.PlayerRequest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
 import java.net.URI;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.now.naaga.common.exception.CommonExceptionType.INVALID_REQUEST_PARAMETERS;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/games")
 @RestController
@@ -76,12 +92,9 @@ public class GameController {
                 .body(GameResponse.from(game));
     }
 
-    @GetMapping
+    @GetMapping(params = "status")
     public ResponseEntity<List<GameResponse>> findGamesByGameStatus(@Auth final PlayerRequest playerRequest,
-                                                                    @RequestParam(required = false) final String status) {
-        if (status == null) {
-            return findAllGames(playerRequest);
-        }
+                                                                    @RequestParam final String status) {
         final FindGameByStatusCommand findGameByStatusCommand = FindGameByStatusCommand.of(playerRequest, status);
         final List<Game> games = gameService.findGamesByStatus(findGameByStatusCommand);
         final List<GameResponse> gameResponses = GameResponse.convertToGameResponses(games);
@@ -90,7 +103,8 @@ public class GameController {
                 .body(gameResponses);
     }
 
-    private ResponseEntity<List<GameResponse>> findAllGames(final PlayerRequest playerRequest) {
+    @GetMapping(params = "!status")
+    public ResponseEntity<List<GameResponse>> findAllGames(@Auth final PlayerRequest playerRequest) {
         final FindAllGamesCommand findALlGamesCommand = FindAllGamesCommand.of(playerRequest);
         final List<Game> games = gameService.findAllGames(findALlGamesCommand);
         final List<GameResponse> gameResponses = GameResponse.convertToGameResponses(games);
@@ -110,16 +124,16 @@ public class GameController {
 
     @GetMapping("/results")
     public ResponseEntity<List<GameResultResponse>> findAllGameResult(@Auth final PlayerRequest playerRequest,
-                                                                      @RequestParam(name = "sort-by") final String sortBy,
-                                                                      @RequestParam(name = "order") final String order) {
+                                                                      @RequestParam(name = "sort-by", defaultValue = "TIME") final String sortBy,
+                                                                      @RequestParam(name = "order", defaultValue = "DESCENDING") final String order) {
         if (!sortBy.equalsIgnoreCase("TIME") || !order.equalsIgnoreCase("DESCENDING")) {
             throw new CommonException(INVALID_REQUEST_PARAMETERS);
         }
 
         final List<GameRecord> gameRecords = gameService.findAllGameResult(playerRequest);
         final List<GameResultResponse> gameResultResponseList = gameRecords.stream()
-                .map(GameResultResponse::from)
-                .collect(Collectors.toList());
+                                                                           .map(GameResultResponse::from)
+                                                                           .toList();
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/backend/src/main/java/com/now/naaga/place/domain/SortType.java
+++ b/backend/src/main/java/com/now/naaga/place/domain/SortType.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 
 public enum SortType {
+
     TIME((places, orderType) -> {
         if (orderType == OrderType.ASCENDING) {
             places.sort(Comparator.comparing(Place::getCreatedAt));

--- a/backend/src/main/java/com/now/naaga/place/presentation/PlaceController.java
+++ b/backend/src/main/java/com/now/naaga/place/presentation/PlaceController.java
@@ -33,8 +33,8 @@ public class PlaceController {
 
     @GetMapping
     public ResponseEntity<List<PlaceResponse>> findAllPlace(@Auth final PlayerRequest playerRequest,
-                                                            @RequestParam(name = "sort-by") final String sortBy,
-                                                            @RequestParam(name = "order") final String order) {
+                                                            @RequestParam(name = "sort-by", defaultValue = "TIME") final String sortBy,
+                                                            @RequestParam(name = "order", defaultValue = "DESCENDING") final String order) {
         final FindAllPlaceCommand findAllPlaceCommand = FindAllPlaceCommand.of(playerRequest, sortBy, order);
         final List<Place> places = placeService.findAllPlace(findAllPlaceCommand);
         final List<PlaceResponse> response = PlaceResponse.convertToPlaceResponses(places);


### PR DESCRIPTION
## 📌 관련 이슈
- close: #224 

## 🛠️ 작업 내용
- [x] query string이 필요한 API에서, query string이 없어도 예외를 발생시키지 않도록 수정

## 🎯 리뷰 포인트

# 수정 사항

- 기존 GameController 에서 status 값이 null 인지에 대한 분기문을 삭제하고, `@RequestMapping` 의 params 속성을 사용하여 매핑 메서드를 분리하였습니다.

- 쿼리 스트링에 대해 defaultValue 를 두어서, 쿼리 스트링이 들어오지 않더라도 예외가 발생되지 않도록 수정하였습니다.

## ⏳ 작업 시간
추정 시간:   1시간
실제 시간:   1시간
