### PR TITLE
fix: 쪽지가 긴 경우 보이지 않는 경우 해결

### DIFF
--- a/android/app/src/main/res/layout/item_letter.xml
+++ b/android/app/src/main/res/layout/item_letter.xml
@@ -44,7 +44,7 @@
         <TextView
             android:id="@+id/tv_item_letter"
             android:layout_width="0dp"
-            android:layout_height="40dp"
+            android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/space_default_large"
             android:gravity="center"
             android:textColor="@color/main_dark_blue"


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #506 

## 🛠️ 작업 내용
- [x] 쪽지 뷰 Height를 wrap_content로 변경한다

## 🎯 리뷰 포인트

### Before
<img src="https://github.com/woowacourse-teams/2023-naaga/assets/84285337/ed23e2ad-4b35-407f-8490-2011103c1eff" width=220>

### After
<img src="https://github.com/woowacourse-teams/2023-naaga/assets/84285337/a82b107c-fbef-41a2-bb1f-0b00d3d8d6b9" width=220>


## ⏳ 작업 시간
추정 시간: 20m  
실제 시간: 20m  