### PR TITLE
fix: 다이얼로그 중첩 현상 수정

### DIFF
--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -60,6 +60,15 @@ class OnAdventureActivity :
         setClickListeners()
     }
 
+    override fun onPause() {
+        super.onPause()
+        supportFragmentManager.fragments.forEach { fragment ->
+            if (fragment.tag == GIVE_UP || fragment.tag == HINT || fragment.tag == LETTER) {
+                supportFragmentManager.beginTransaction().remove(fragment).commit()
+            }
+        }
+    }
+
     private var backPressedTime = 0L
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #510 

## 🛠️ 작업 내용
- [X] 앱을 나갔다 들어왔을 때 다이얼로그가 중첩되지 않도록 수정

## 🎯 리뷰 포인트
- 문제가 되었던 힌트, 쪽지, 그만하기 다이얼로그를 앱 나갔다 들어올 시 해당 태그를 갖고 있는 다이얼로그들을 찾아서 삭제해주도록 하였습니다
- onPause() 에서 해당 로직을 수행하고 있습니다. 

## ⏳ 작업 시간
추정 시간:  1h 
실제 시간:  1h 
