### PR TITLE
refactor: 도전 실패 반응 확인 기능 구현

### DIFF
--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -145,7 +145,7 @@ class OnAdventureActivity :
 
                 OnAdventureViewModel.NOT_ARRIVED -> {
                     val remainingTryCount: Int = viewModel.adventure.value?.remainingTryCount?.toInt() ?: 0
-                    shortSnackbar(getString(R.string.onAdventure_retry, remainingTryCount))
+                    showToast(getString(R.string.onAdventure_retry, remainingTryCount))
                 }
 
                 OnAdventureViewModel.TRY_COUNT_OVER -> showToast(getString(R.string.onAdventure_try_count_over))

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureViewModel.kt
@@ -144,12 +144,18 @@ class OnAdventureViewModel @Inject constructor(
 
     private fun handleGameThrowable(throwable: GameThrowable) {
         when (throwable.code) {
-            TRY_COUNT_OVER -> _adventure.value = adventure.value?.copy(adventureStatus = AdventureStatus.DONE)
+            TRY_COUNT_OVER -> {
+                _adventure.value = adventure.value?.copy(adventureStatus = AdventureStatus.DONE)
+                _throwable.value = throwable
+            }
             NOT_ARRIVED -> {
                 val currentRemainingTryCount = adventure.value?.remainingTryCount ?: return
                 _adventure.value = adventure.value?.copy(remainingTryCount = currentRemainingTryCount - 1)
+                _throwable.value = throwable
             }
-            else -> { _throwable.value = throwable }
+            else -> {
+                _throwable.value = throwable
+            }
         }
     }
 
@@ -172,14 +178,15 @@ class OnAdventureViewModel @Inject constructor(
             }.onSuccess {
                 _isSendLetterSuccess.value = true
             }.onFailure {
+                setThrowable(it)
             }
         }
     }
 
     private fun setThrowable(throwable: Throwable) {
         when (throwable) {
-            is IOException -> { _throwable.value = DataThrowable.NetworkThrowable() }
-            is GameThrowable -> { handleGameThrowable(throwable) }
+            is IOException -> _throwable.value = DataThrowable.NetworkThrowable()
+            is GameThrowable -> handleGameThrowable(throwable)
             is UniversalThrowable -> _throwable.value = throwable
         }
     }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #543 

## 🛠️ 작업 내용
- [X] 도전 실패시 도전 횟수가 몇회 남았는지 토스트를 띄워 사용자가 알 수 있도록 수정

## 🎯 리뷰 포인트
- `OnAdventure`의 `handleGameThrowable`에서 `_throwable.value = throwable` 설정을 해주지 않아 남은 시도 횟수 알림이 보이지 않던 것 이였습니다. 지금은 throwable 을 설정해주어 throwable의 옵저버가 해당 변화를 인식하고 그때에 맞게 남은 횟수 토스트를 띄워 줍니다.
- 기존에는 알림이 snackbar 형태였었는데 토스트로 변경하였습니다. 개인적 취향으로 스낵바 보다 토스트가 더 눈에 띄더라고요... 리뷰어님의 의견도 궁금합니다! 기존 스낵바 형태로 유지하는게 좋을까요?

## ⏳ 작업 시간
추정 시간:  1h 
실제 시간:  2h 
이유: 어디가 문제인지 몰라서 빙글빙글 코드 타고타고 돌고돌고 돌아다니는 여정이 생각보다 길어져서 시간이 오래 걸렸습니다. 
