### PR TITLE
Fix/#545 리프레시 토큰 로직 수정

### DIFF
--- a/android/app/src/main/java/com/now/naaga/data/remote/dto/post/RefreshTokenDto.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/dto/post/RefreshTokenDto.kt
@@ -1,0 +1,10 @@
+package com.now.naaga.data.remote.dto.post
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RefreshTokenDto(
+    @SerialName("refreshToken")
+    val refreshToken: String,
+)

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/AuthInterceptor.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/AuthInterceptor.kt
@@ -1,31 +1,14 @@
 package com.now.naaga.data.remote.retrofit
 
-import com.google.gson.Gson
-import com.google.gson.JsonParser
 import com.now.domain.repository.AuthRepository
-import com.now.naaga.BuildConfig
-import com.now.naaga.data.remote.dto.FailureDto
-import com.now.naaga.data.remote.dto.NaagaAuthDto
-import com.now.naaga.data.throwable.DataThrowable
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import okhttp3.Interceptor
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.internal.closeQuietly
-import org.json.JSONObject
 
 class AuthInterceptor(
     private val authRepository: AuthRepository,
 ) : Interceptor {
-    private val gson = Gson()
-    private val client = OkHttpClient.Builder().build()
-
     override fun intercept(chain: Interceptor.Chain): Response {
         val accessToken = authRepository.getAccessToken() ?: return chain.proceed(chain.request())
 
@@ -33,65 +16,18 @@ class AuthInterceptor(
         val response: Response = chain.proceed(headerAddedRequest)
 
         if (response.code == 401) {
-            val newAccessToken = getAccessTokenAfterRefresh(accessToken).getOrElse { return response }
             response.closeQuietly()
-            return chain.proceed(chain.request().newBuilder().addHeader(AUTH_KEY, newAccessToken).build())
+            runBlocking {
+                authRepository.refreshAccessToken()
+            }
+            return chain.proceed(
+                chain.request().newBuilder().addHeader(AUTH_KEY, authRepository.getAccessToken()!!).build(),
+            )
         }
         return response
     }
 
-    private fun getAccessTokenAfterRefresh(accessToken: String): Result<String> {
-        val requestBody = createRefreshRequestBody()
-        val request = createRefreshRequest(requestBody, accessToken)
-
-        val auth: NaagaAuthDto = requestRefresh(request).getOrElse {
-            return Result.failure(it)
-        }
-        authRepository.storeToken(auth.accessToken, auth.refreshToken)
-        return Result.success(BEARER + auth.accessToken)
-    }
-
-    private fun createRefreshRequestBody(): RequestBody {
-        return JSONObject()
-            .put(AUTH_REFRESH_KEY, authRepository.getRefreshToken())
-            .toString()
-            .toRequestBody(contentType = "application/json".toMediaType())
-    }
-
-    private fun createRefreshRequest(requestBody: RequestBody, accessToken: String): Request {
-        return Request.Builder()
-            .url(BuildConfig.BASE_URL + AUTH_REFRESH_PATH)
-            .post(requestBody)
-            .addHeader(AUTH_KEY, accessToken)
-            .build()
-    }
-
-    private fun requestRefresh(request: Request): Result<NaagaAuthDto> {
-        val response: Response = runBlocking {
-            withContext(Dispatchers.IO) { client.newCall(request).execute() }
-        }
-        if (response.isSuccessful) {
-            return Result.success(response.getDto<NaagaAuthDto>())
-        }
-        val failedResponse = response.getDto<FailureDto>()
-        if (failedResponse.code == 101) {
-            return Result.failure(DataThrowable.AuthorizationThrowable(failedResponse.code, failedResponse.message))
-        }
-        return Result.failure(IllegalStateException(REFRESH_FAILURE))
-    }
-
-    private inline fun <reified T> Response.getDto(): T {
-        val responseObject = JsonParser.parseString(body?.string()).asJsonObject
-        return gson.fromJson(responseObject, T::class.java)
-    }
-
     companion object {
         private const val AUTH_KEY = "Authorization"
-        private const val AUTH_REFRESH_KEY = "refreshToken"
-
-        private const val AUTH_REFRESH_PATH = "auth/refresh"
-
-        private const val BEARER = "Bearer "
-        private const val REFRESH_FAILURE = "토큰 리프레시 실패"
     }
 }

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/AuthInterceptor.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/AuthInterceptor.kt
@@ -17,8 +17,8 @@ class AuthInterceptor(
 
         if (response.code == 401) {
             response.closeQuietly()
-            runBlocking {
-                authRepository.refreshAccessToken()
+            runCatching {
+                runBlocking { authRepository.refreshAccessToken() }
             }
             return chain.proceed(
                 chain.request().newBuilder().addHeader(AUTH_KEY, authRepository.getAccessToken()!!).build(),

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
@@ -5,6 +5,7 @@ import com.now.naaga.data.remote.dto.PlatformAuthDto
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface AuthService {
@@ -14,8 +15,12 @@ interface AuthService {
     ): Response<NaagaAuthDto>
 
     @DELETE("/auth/unlink")
-    suspend fun withdrawalMember(): Response<Unit>
+    suspend fun withdrawalMember(
+        @Header("Authorization") accessToken: String,
+    ): Response<Unit>
 
     @DELETE("/auth")
-    suspend fun requestLogout(): Response<Unit>
+    suspend fun requestLogout(
+        @Header("Authorization") accessToken: String,
+    ): Response<Unit>
 }

--- a/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
+++ b/android/app/src/main/java/com/now/naaga/data/remote/retrofit/service/AuthService.kt
@@ -2,6 +2,7 @@ package com.now.naaga.data.remote.retrofit.service
 
 import com.now.naaga.data.remote.dto.NaagaAuthDto
 import com.now.naaga.data.remote.dto.PlatformAuthDto
+import com.now.naaga.data.remote.dto.post.RefreshTokenDto
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -23,4 +24,9 @@ interface AuthService {
     suspend fun requestLogout(
         @Header("Authorization") accessToken: String,
     ): Response<Unit>
+
+    @POST("/auth/refresh")
+    suspend fun requestRefresh(
+        @Body refreshToken: RefreshTokenDto,
+    ): Response<NaagaAuthDto>
 }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -8,34 +8,25 @@ import com.now.naaga.data.remote.dto.post.RefreshTokenDto
 import com.now.naaga.data.remote.retrofit.service.AuthService
 import com.now.naaga.util.extension.getValueOrThrow
 import com.now.naaga.util.unlinkWithKakao
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 class DefaultAuthRepository(
     private val authDataSource: AuthDataSource,
     private val authService: AuthService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AuthRepository {
 
     override suspend fun logIn(platformAuth: PlatformAuth): Boolean {
-        return withContext(dispatcher) {
-            val response = authService.requestAuth(platformAuth.toDto())
-            runCatching {
-                val naagaAuthDto = response.getValueOrThrow()
-                storeToken(naagaAuthDto.accessToken, naagaAuthDto.refreshToken)
-                return@withContext true
-            }
-            return@withContext false
+        val response = authService.requestAuth(platformAuth.toDto())
+        runCatching {
+            val naagaAuthDto = response.getValueOrThrow()
+            storeToken(naagaAuthDto.accessToken, naagaAuthDto.refreshToken)
         }
+        return true
     }
 
     override suspend fun logout() {
-        withContext(dispatcher) {
-            val response = authService.requestLogout(getAccessToken()!!)
-            authDataSource.resetToken()
-            response.getValueOrThrow()
-        }
+        val response = authService.requestLogout(getAccessToken()!!)
+        authDataSource.resetToken()
+        response.getValueOrThrow()
     }
 
     override suspend fun withdrawalMember() {

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -28,7 +28,8 @@ class DefaultAuthRepository(
     }
 
     override suspend fun withdrawalMember() {
-        authService.withdrawalMember(getAccessToken()!!)
+        val response = authService.withdrawalMember(getAccessToken()!!)
+        response.getValueOrThrow()
         unlinkWithKakao()
     }
 

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -16,10 +16,8 @@ class DefaultAuthRepository(
 
     override suspend fun logIn(platformAuth: PlatformAuth): Boolean {
         val response = authService.requestAuth(platformAuth.toDto())
-        runCatching {
-            val naagaAuthDto = response.getValueOrThrow()
-            storeToken(naagaAuthDto.accessToken, naagaAuthDto.refreshToken)
-        }
+        val naagaAuthDto = response.getValueOrThrow()
+        storeToken(naagaAuthDto.accessToken, naagaAuthDto.refreshToken)
         return true
     }
 

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -4,6 +4,7 @@ import com.now.domain.model.PlatformAuth
 import com.now.domain.repository.AuthRepository
 import com.now.naaga.data.local.AuthDataSource
 import com.now.naaga.data.mapper.toDto
+import com.now.naaga.data.remote.dto.post.RefreshTokenDto
 import com.now.naaga.data.remote.retrofit.service.AuthService
 import com.now.naaga.util.extension.getValueOrThrow
 import com.now.naaga.util.unlinkWithKakao
@@ -53,6 +54,12 @@ class DefaultAuthRepository(
     override fun storeToken(accessToken: String, refreshToken: String) {
         authDataSource.setAccessToken(accessToken)
         authDataSource.setRefreshToken(refreshToken)
+    }
+
+    override suspend fun refreshAccessToken() {
+        val response = authService.requestRefresh(RefreshTokenDto(authDataSource.getRefreshToken()!!))
+        val naagaAuthDto = response.getValueOrThrow()
+        storeToken(naagaAuthDto.accessToken, naagaAuthDto.refreshToken)
     }
 
     companion object {

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -31,14 +31,14 @@ class DefaultAuthRepository(
 
     override suspend fun logout() {
         withContext(dispatcher) {
-            val response = authService.requestLogout()
+            val response = authService.requestLogout(authDataSource.getAccessToken()!!)
             authDataSource.resetToken()
             response.getValueOrThrow()
         }
     }
 
     override suspend fun withdrawalMember() {
-        authService.withdrawalMember()
+        authService.withdrawalMember(authDataSource.getAccessToken()!!)
         unlinkWithKakao()
     }
 

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -32,14 +32,14 @@ class DefaultAuthRepository(
 
     override suspend fun logout() {
         withContext(dispatcher) {
-            val response = authService.requestLogout(authDataSource.getAccessToken()!!)
+            val response = authService.requestLogout(getAccessToken()!!)
             authDataSource.resetToken()
             response.getValueOrThrow()
         }
     }
 
     override suspend fun withdrawalMember() {
-        authService.withdrawalMember(authDataSource.getAccessToken()!!)
+        authService.withdrawalMember(getAccessToken()!!)
         unlinkWithKakao()
     }
 
@@ -57,7 +57,7 @@ class DefaultAuthRepository(
     }
 
     override suspend fun refreshAccessToken() {
-        val response = authService.requestRefresh(RefreshTokenDto(authDataSource.getRefreshToken()!!))
+        val response = authService.requestRefresh(RefreshTokenDto(getRefreshToken()))
         val naagaAuthDto = response.getValueOrThrow()
         storeToken(naagaAuthDto.accessToken, naagaAuthDto.refreshToken)
     }

--- a/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
+++ b/android/app/src/main/java/com/now/naaga/data/repository/DefaultAuthRepository.kt
@@ -23,8 +23,8 @@ class DefaultAuthRepository(
 
     override suspend fun logout() {
         val response = authService.requestLogout(getAccessToken()!!)
-        authDataSource.resetToken()
         response.getValueOrThrow()
+        authDataSource.resetToken()
     }
 
     override suspend fun withdrawalMember() {

--- a/android/app/src/main/java/com/now/naaga/di/ServiceModule.kt
+++ b/android/app/src/main/java/com/now/naaga/di/ServiceModule.kt
@@ -1,6 +1,7 @@
 package com.now.naaga.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.now.domain.repository.AuthRepository
 import com.now.naaga.BuildConfig
 import com.now.naaga.data.remote.retrofit.AuthInterceptor
 import com.now.naaga.data.remote.retrofit.service.AdventureService
@@ -17,7 +18,16 @@ import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
+import javax.inject.Qualifier
 import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthRetrofit
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class NormalRetrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -26,39 +36,53 @@ class ServiceModule {
 
     @Singleton
     @Provides
-    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder().apply {
-        addInterceptor(AuthInterceptor())
+    fun provideOkHttpClient(authRepository: AuthRepository): OkHttpClient = OkHttpClient.Builder().apply {
+        addInterceptor(AuthInterceptor(authRepository))
     }.build()
 
+    @AuthRetrofit
     @Singleton
     @Provides
-    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit = Retrofit.Builder()
+    fun provideAuthRetrofit(okHttpClient: OkHttpClient): Retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
         .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
         .client(okHttpClient)
         .build()
 
+    @NormalRetrofit
     @Singleton
     @Provides
-    fun provideRankService(retrofit: Retrofit): RankService = retrofit.create(RankService::class.java)
+    fun provideNormalRetrofit(): Retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .addConverterFactory(Json.asConverterFactory("application/json".toMediaType()))
+        .build()
 
     @Singleton
     @Provides
-    fun provideStatisticsService(retrofit: Retrofit): StatisticsService = retrofit.create(StatisticsService::class.java)
+    fun provideRankService(@AuthRetrofit retrofit: Retrofit): RankService = retrofit.create(RankService::class.java)
 
     @Singleton
     @Provides
-    fun provideAdventureService(retrofit: Retrofit): AdventureService = retrofit.create(AdventureService::class.java)
+    fun provideStatisticsService(@AuthRetrofit retrofit: Retrofit): StatisticsService = retrofit.create(
+        StatisticsService::class.java,
+    )
 
     @Singleton
     @Provides
-    fun providePlaceService(retrofit: Retrofit): PlaceService = retrofit.create(PlaceService::class.java)
+    fun provideAdventureService(@AuthRetrofit retrofit: Retrofit): AdventureService = retrofit.create(
+        AdventureService::class.java,
+    )
 
     @Singleton
     @Provides
-    fun provideAuthService(retrofit: Retrofit): AuthService = retrofit.create(AuthService::class.java)
+    fun providePlaceService(@AuthRetrofit retrofit: Retrofit): PlaceService = retrofit.create(PlaceService::class.java)
 
     @Singleton
     @Provides
-    fun provideLetterService(retrofit: Retrofit): LetterService = retrofit.create(LetterService::class.java)
+    fun provideAuthService(@NormalRetrofit retrofit: Retrofit): AuthService = retrofit.create(AuthService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideLetterService(@AuthRetrofit retrofit: Retrofit): LetterService =
+        retrofit.create(LetterService::class.java)
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/login/LoginViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/login/LoginViewModel.kt
@@ -26,7 +26,7 @@ class LoginViewModel @Inject constructor(
     fun signIn(token: String, platformType: AuthPlatformType) {
         viewModelScope.launch {
             runCatching {
-                authRepository.getToken(PlatformAuth(token, platformType))
+                authRepository.logIn(PlatformAuth(token, platformType))
             }.onSuccess { status ->
                 _isLoginSucceed.value = status
             }.onFailure {

--- a/android/app/src/main/java/com/now/naaga/presentation/mypage/MyPageActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/mypage/MyPageActivity.kt
@@ -51,9 +51,7 @@ class MyPageActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
     }
 
     private fun fetchData() {
-        viewModel.fetchRank()
-        viewModel.fetchStatistics()
-        viewModel.fetchPlaces()
+        viewModel.fetchData()
     }
 
     private fun subscribe() {

--- a/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/onadventure/OnAdventureActivity.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -76,11 +75,7 @@ class OnAdventureActivity :
                 finish()
             } else {
                 backPressedTime = System.currentTimeMillis()
-                Toast.makeText(
-                    this@OnAdventureActivity,
-                    getString(R.string.OnAdventure_warning_back_pressed),
-                    Toast.LENGTH_SHORT,
-                ).show()
+                showToast(getString(R.string.OnAdventure_warning_back_pressed))
             }
         }
     }
@@ -177,7 +172,7 @@ class OnAdventureActivity :
             return
         }
 
-        Toast.makeText(this, getString(R.string.OnAdventure_continue_adventure), Toast.LENGTH_SHORT).show()
+        showToast(getString(R.string.OnAdventure_continue_adventure))
         viewModel.setAdventure(existingAdventure)
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashActivity.kt
@@ -16,6 +16,7 @@ import com.now.naaga.data.throwable.DataThrowable
 import com.now.naaga.presentation.beginadventure.BeginAdventureActivity
 import com.now.naaga.presentation.common.dialog.NaagaAlertDialog
 import com.now.naaga.presentation.login.LoginActivity
+import com.now.naaga.presentation.splash.SplashViewModel.Companion.EXPIRATION_AUTH_ERROR_CODE
 import com.now.naaga.util.extension.getPackageInfoCompat
 import com.now.naaga.util.extension.showToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -85,6 +86,7 @@ class SplashActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
         viewModel.throwable.observe(this) { throwable: DataThrowable ->
             when (throwable.code) {
                 DataThrowable.NETWORK_THROWABLE_CODE -> { showToast(getString(R.string.network_error_message)) }
+                EXPIRATION_AUTH_ERROR_CODE -> { showToast(getString(R.string.splash_re_login_message)) }
             }
         }
     }

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashViewModel.kt
@@ -35,8 +35,9 @@ class SplashViewModel @Inject constructor(private val statisticsRepository: Stat
 
     private fun setThrowable(throwable: Throwable) {
         when (throwable) {
-            is IOException -> { _throwable.value = DataThrowable.NetworkThrowable() }
-            is DataThrowable.AuthorizationThrowable -> { _throwable.value = throwable }
+            is IOException -> {
+                _throwable.value = DataThrowable.AuthorizationThrowable(EXPIRATION_AUTH_ERROR_CODE, "")
+            }
         }
     }
 

--- a/android/app/src/main/java/com/now/naaga/presentation/splash/SplashViewModel.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/splash/SplashViewModel.kt
@@ -39,4 +39,8 @@ class SplashViewModel @Inject constructor(private val statisticsRepository: Stat
             is DataThrowable.AuthorizationThrowable -> { _throwable.value = throwable }
         }
     }
+
+    companion object {
+        const val EXPIRATION_AUTH_ERROR_CODE = 102
+    }
 }

--- a/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
+++ b/android/app/src/main/java/com/now/naaga/presentation/upload/UploadActivity.kt
@@ -45,7 +45,7 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
     private val cameraLauncher = registerForActivityResult(ActivityResultContracts.TakePicture()) { success ->
         if (!success) return@registerForActivityResult
         if (imageUri == null) {
-            showToast(getString(R.string.upload_image_orientation_error))
+            showToast(getString(R.string.upload_image_orientation_error_message))
             return@registerForActivityResult
         }
         setImage(requireNotNull(imageUri) { "imageUri가 null입니다" })
@@ -247,7 +247,7 @@ class UploadActivity : AppCompatActivity(), AnalyticsDelegate by DefaultAnalytic
 
     private fun openCamera() {
         imageUri = createImageUri().getOrElse {
-            Snackbar.make(binding.root, getString(R.string.upload_retry), Snackbar.LENGTH_SHORT).show()
+            Snackbar.make(binding.root, getString(R.string.upload_retry_message), Snackbar.LENGTH_SHORT).show()
             return
         }
         cameraLauncher.launch(imageUri)

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -63,8 +63,11 @@
     <string name="upload_error_post_message">전송에 실패했어요! 다시 시도해주세요!</string>
     <string name="upload_error_insufficient_info_message">모든 정보를 입력해주세요.</string>
     <string name="upload_image_error_message">사진 가져오기에 실패했습니다</string>
-    <string name="upload_image_orientation_error">실패했습니다. 사진을 세로로 찍어보세요!</string>
-    <string name="upload_retry">다시 시도해 주세요!</string>
+    <string name="upload_image_orientation_error_message">실패했습니다. 사진을 세로로 찍어보세요!</string>
+    <string name="upload_retry_message">다시 시도해 주세요!</string>
+
+    <!-- SplashActivity -->
+    <string name="splash_re_login_message">인증 정보가 만료 되었어요!\n다시 로그인 해주세요!</string>
 
     <!-- AdventureHistoryActivity -->
     <string name="history_title">모험 기록</string>
@@ -108,7 +111,7 @@
 
     <!-- SettingActivity -->
     <string name="setting_withdrawal_success_message">"성공적으로 회원 탈퇴 되었습니다."</string>
-    <string name="setting_wrong_error_message">"인증 정보가 잘 못 되었어요!"</string>
+    <string name="setting_wrong_error_message">"인증 정보가 잘못 되었어요!"</string>
     <string name="setting_expiration_error_message">"인증 정보가 만료 되었어요!"</string>
     <string name="setting_logout_message">로그아웃 되었습니다.</string>
     <string name="setting_title">설정</string>

--- a/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
+++ b/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
@@ -6,6 +6,7 @@ interface AuthRepository {
     suspend fun logIn(platformAuth: PlatformAuth): Boolean
     suspend fun withdrawalMember()
     suspend fun logout()
+    suspend fun refreshAccessToken()
 
     fun getAccessToken(): String?
     fun getRefreshToken(): String

--- a/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
+++ b/android/domain/src/main/java/com/now/domain/repository/AuthRepository.kt
@@ -3,7 +3,11 @@ package com.now.domain.repository
 import com.now.domain.model.PlatformAuth
 
 interface AuthRepository {
-    suspend fun getToken(platformAuth: PlatformAuth): Boolean
+    suspend fun logIn(platformAuth: PlatformAuth): Boolean
     suspend fun withdrawalMember()
     suspend fun logout()
+
+    fun getAccessToken(): String?
+    fun getRefreshToken(): String
+    fun storeToken(accessToken: String, refreshToken: String)
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #545 

## 🛠️ 작업 내용
- [x] Interceptor에 있던 리프레시 로직을 AuthRepository로 이동
- [x] Interceptor가 AuthRepository를 갖도록 변경
- [x] MyPageViewModel 에서 비동기로 보내는 3번의 요청을 하나의 요청을 기다린 뒤 전송하도록 변경
- [x] 리프레시 토큰이 만료된 경우 비정상 종료되는 문제 수정

## 🎯 리뷰 포인트
- AuthInterceptor가 AuthRepository를 갖게 하는 것에 대해 어떻게 생각하는지 궁금합니다.
- 로그아웃 or 회원탈퇴를 진행하는 경우 액세스 토큰 대신 리프레시 토큰을 사용하는 것은 어떻게 생각하는지 궁금합니다.
  - 로그아웃 or 회원탈퇴를 하기 위해 어떤 토큰을 사용하는 것이 올바르고 더 나을지에 대해서는 안드로이드 뿐 아니라 백엔드 팀원들과도 이야기를 나눠보면 좋을 것 같다는 생각이 들었어요.
  - 현재 올린 PR에서는 로그아웃, 회원탈퇴 모두 실패하는 것으로 해두었습니다. 

### AuthInterceptor
- AuthRepository를 가지도록 했고 이렇게 만든 이유는 역할과 책임을 명확히 분리하고 싶었기 때문입니다. AuthRepository는 토큰에 대한 관리만을, AuthInterceptor에서는 네트워크 작업에 대한 요청만을 하도록 나누고 싶었습니다. 
- 관계없는 내용일 수 있지만, 리팩터링을 진행하면서 느낀 것은 역할과 책임을 분리한 경우 가독성도 좋아졌고 RequestBody나 URL을 직접 만들어주지 않고 retrofit2를 사용할 수 있기에 이전에 겪었던 문제들을 마주할 확률이 줄어들겠다였습니다.

## ⏳ 작업 시간
추정 시간: 4h  
실제 시간: 17h 

AuthInterceptor에 있는 리프레시 로직을 AuthRepository로 이동시키는 과정에서 부수적인 문제들이 발생해서 고민하고 고치느라 시간이 더 소요되었습니다.  
정말 고려할 것이 많군요. 리프레시,,,