### PR TITLE
test: TestContainers 적용

### DIFF
--- a/.github/workflows/backend_dev_merge_workflow.yml
+++ b/.github/workflows/backend_dev_merge_workflow.yml
@@ -1,9 +1,10 @@
-name: NAAGA BACKEND MERGE CI
+name: NAAGA BACKEND PRODUCT SERVER MERGE CI/CD
+
 on:
   push:
     branches:
       - dev_backend
-
+      
 jobs:
   github_actions_setting:
     runs-on: ubuntu-latest
@@ -41,18 +42,17 @@ jobs:
       - name: 🐳 도커 이미지 빌드 중... 🐳
         run: |
           cd backend
-          docker build --platform linux/arm64/v8 -t ${{ secrets.DOCKERHUB_REPOSITORY }}/${{ secrets.DOCKERHUB_APPNAME }} -f Dockerfile-dev .
+          docker build --platform linux/arm64/v8 -t ${{ secrets.DOCKERHUB_REPOSITORY }}/${{ secrets.DOCKERHUB_APPNAME }} -f Dockerfile-prod .
 
       - name: 🐳 도커 허브에 Push 중... 🐳
         run: docker push ${{ secrets.DOCKERHUB_REPOSITORY }}/${{ secrets.DOCKERHUB_APPNAME }}
 
-  naaga_dev_ec2_deploy:
+  naaga_prod_ec2_deploy:
     needs: github_actions_setting
     runs-on: naaga
 
     steps:
       - name: 🙏 쉘 스크립트 실행 중 ... 🙏
         run: |
-          cd /home/ubuntu
-          sudo ./deploy_new.sh
-
+          cd /home/ubuntu/prod
+          sudo ./deploy_prod.sh

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured:5.3.1'
+	testImplementation 'org.testcontainers:mysql:1.19.2'
 }
 
 tasks.named('test') {

--- a/backend/src/test/java/com/now/naaga/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/auth/application/AuthServiceTest.java
@@ -11,7 +11,7 @@ import com.now.naaga.auth.domain.AuthToken;
 import com.now.naaga.auth.infrastructure.AuthType;
 import com.now.naaga.auth.infrastructure.dto.AuthInfo;
 import com.now.naaga.auth.infrastructure.dto.MemberAuth;
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.member.domain.Member;
 import com.now.naaga.player.domain.Player;
 import com.now.naaga.score.domain.Score;
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
-class AuthServiceTest extends ServiceTest {
+class AuthServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private AuthService authService;

--- a/backend/src/test/java/com/now/naaga/auth/presentation/AuthControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/auth/presentation/AuthControllerTest.java
@@ -17,7 +17,7 @@ import com.now.naaga.auth.infrastructure.dto.MemberAuth;
 import com.now.naaga.auth.presentation.dto.AuthRequest;
 import com.now.naaga.auth.presentation.dto.AuthResponse;
 import com.now.naaga.auth.presentation.dto.RefreshTokenRequest;
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.common.exception.ExceptionResponse;
 import com.now.naaga.member.domain.Member;
 import com.now.naaga.player.domain.Player;
@@ -31,7 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @SuppressWarnings("NonAsciiCharacters")
-class AuthControllerTest extends ControllerTest {
+class AuthControllerTest extends MySqlContainerControllerTest {
 
     @Test
     void 이미_존재하는_멤버_정보로_카카오_토큰을_통해서_로그인_요청을_하면_액세스_토큰을_발급한다() {

--- a/backend/src/test/java/com/now/naaga/auth/presentation/AuthInterceptorTest.java
+++ b/backend/src/test/java/com/now/naaga/auth/presentation/AuthInterceptorTest.java
@@ -8,21 +8,18 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.now.naaga.auth.domain.AuthToken;
 import com.now.naaga.auth.infrastructure.AuthType;
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.common.exception.ExceptionResponse;
 import com.now.naaga.member.domain.Member;
 import com.now.naaga.player.domain.Player;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayNameGeneration;
-import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 @SuppressWarnings("NonAsciiCharacters")
-public class AuthInterceptorTest extends ControllerTest {
+public class AuthInterceptorTest extends MySqlContainerControllerTest {
 
     @Test
     void 인증_헤더_정보가_존재하지_않을_때_401_응답한다() {

--- a/backend/src/test/java/com/now/naaga/auth/presentation/PlayerArgumentResolverTest.java
+++ b/backend/src/test/java/com/now/naaga/auth/presentation/PlayerArgumentResolverTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.now.naaga.auth.domain.AuthToken;
 import com.now.naaga.auth.infrastructure.AuthType;
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.common.exception.ExceptionResponse;
 import com.now.naaga.player.domain.Player;
 import io.restassured.RestAssured;
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 @SuppressWarnings("NonAsciiCharacters")
-public class PlayerArgumentResolverTest extends ControllerTest {
+public class PlayerArgumentResolverTest extends MySqlContainerControllerTest {
 
     @Test
     void 인증_헤더의_토큰_정보가_존재하지_않는_멤버일_때_예외를_발생한다() {

--- a/backend/src/test/java/com/now/naaga/auth/presentation/interceptor/ManagerAuthInterceptorTest.java
+++ b/backend/src/test/java/com/now/naaga/auth/presentation/interceptor/ManagerAuthInterceptorTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.now.naaga.auth.exception.AuthException;
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -15,7 +15,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.mvc.Controller;
 
 @SuppressWarnings("NonAsciiCharacters")
-class ManagerAuthInterceptorTest extends ControllerTest {
+class ManagerAuthInterceptorTest extends MySqlContainerControllerTest {
 
     @Value("${manager.id}")
     String id;

--- a/backend/src/test/java/com/now/naaga/common/MySqlContainerControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/common/MySqlContainerControllerTest.java
@@ -1,0 +1,52 @@
+package com.now.naaga.common;
+
+import com.now.naaga.auth.domain.AuthToken;
+import com.now.naaga.auth.infrastructure.AuthType;
+import com.now.naaga.auth.infrastructure.jwt.AuthTokenGenerator;
+import com.now.naaga.auth.infrastructure.jwt.JwtProvider;
+import com.now.naaga.member.domain.Member;
+import com.now.naaga.player.domain.Player;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public abstract class MySqlContainerControllerTest extends MySqlContainerTest {
+
+    @Autowired
+    protected AuthTokenGenerator authTokenGenerator;
+
+    @Autowired
+    protected JwtProvider jwtProvider;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    protected String authorizationForBearer(final Player player) {
+        final Member member = player.getMember();
+        final AuthToken generate = authTokenGenerator.generate(member, member.getId(), AuthType.KAKAO);
+        final String accessToken = generate.getAccessToken();
+        return "Bearer " + accessToken;
+    }
+
+    protected String authorizationForBearer(final Member member) {
+        final AuthToken generate = authTokenGenerator.generate(member, member.getId(), AuthType.KAKAO);
+        final String accessToken = generate.getAccessToken();
+        return "Bearer " + accessToken;
+    }
+
+    protected Long getIdFromLocationHeader(ExtractableResponse<Response> extractableResponse) {
+        String[] split = extractableResponse.header("Location").split("/");
+        return Long.parseLong(split[split.length - 1]);
+    }
+}

--- a/backend/src/test/java/com/now/naaga/common/MySqlContainerServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/common/MySqlContainerServiceTest.java
@@ -1,0 +1,8 @@
+package com.now.naaga.common;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public abstract class MySqlContainerServiceTest extends MySqlContainerTest {
+
+}

--- a/backend/src/test/java/com/now/naaga/common/MySqlContainerTest.java
+++ b/backend/src/test/java/com/now/naaga/common/MySqlContainerTest.java
@@ -1,0 +1,19 @@
+package com.now.naaga.common;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
+
+public abstract class MySqlContainerTest extends AbstractTest {
+
+    static final MySQLContainer<?> mySqlContainer = new MySQLContainer<>("mysql:8.0.35");
+
+    @DynamicPropertySource
+    static void mySqlProperties(final DynamicPropertyRegistry registry) {
+        mySqlContainer.start();
+        registry.add("spring.datasource.url", mySqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mySqlContainer::getUsername);
+        registry.add("spring.datasource.password", mySqlContainer::getPassword);
+        registry.add("spring.datasource.driver-class-name", mySqlContainer::getDriverClassName);
+    }
+}

--- a/backend/src/test/java/com/now/naaga/game/application/GameServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/game/application/GameServiceTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.game.application.dto.CreateGameCommand;
 import com.now.naaga.game.application.dto.EndGameCommand;
 import com.now.naaga.game.application.dto.FindGameByIdCommand;
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
-class GameServiceTest extends ServiceTest {
+class GameServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private GameService gameService;

--- a/backend/src/test/java/com/now/naaga/game/application/HintServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/game/application/HintServiceTest.java
@@ -8,7 +8,7 @@ import static com.now.naaga.game.exception.GameExceptionType.HINT_NOT_EXIST_IN_G
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.common.exception.BaseExceptionType;
 import com.now.naaga.game.application.dto.CreateHintCommand;
 import com.now.naaga.game.application.dto.FindHintByIdCommand;
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @SuppressWarnings("NonAsciiCharacters")
-class HintServiceTest extends ServiceTest {
+class HintServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private HintService hintService;

--- a/backend/src/test/java/com/now/naaga/game/presentation/GameControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/game/presentation/GameControllerTest.java
@@ -21,7 +21,7 @@ import static com.now.naaga.gameresult.domain.ResultType.FAIL;
 import static com.now.naaga.gameresult.domain.ResultType.SUCCESS;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.common.exception.ExceptionResponse;
 import com.now.naaga.game.domain.Direction;
 import com.now.naaga.game.domain.Game;
@@ -54,7 +54,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @SuppressWarnings("NonAsciiCharacters")
-class GameControllerTest extends ControllerTest {
+class GameControllerTest extends MySqlContainerControllerTest {
 
     @Test
     void 게임_생성_요청시_진행중인_게임이_없으면서_주변에_추천_장소가_있다면_게임을_정상적으로_생성한다() {

--- a/backend/src/test/java/com/now/naaga/game/presentation/StatisticControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/game/presentation/StatisticControllerTest.java
@@ -4,7 +4,7 @@ import static com.now.naaga.common.fixture.PositionFixture.잠실_루터회관_�
 import static com.now.naaga.common.fixture.PositionFixture.잠실역_교보문고_좌표;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.game.application.GameService;
 import com.now.naaga.game.application.dto.EndGameCommand;
 import com.now.naaga.game.domain.EndType;
@@ -23,7 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @SuppressWarnings("NonAsciiCharacters")
-public class StatisticControllerTest extends ControllerTest {
+public class StatisticControllerTest extends MySqlContainerControllerTest {
 
     @Autowired
     private GameService gameService;

--- a/backend/src/test/java/com/now/naaga/gameresult/application/GameResultServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/gameresult/application/GameResultServiceTest.java
@@ -6,7 +6,7 @@ import static com.now.naaga.game.domain.GameStatus.IN_PROGRESS;
 import static com.now.naaga.gameresult.domain.ResultType.SUCCESS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.game.application.dto.CreateGameResultCommand;
 import com.now.naaga.game.domain.Game;
 import com.now.naaga.game.exception.GameException;
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @SuppressWarnings("NonAsciiCharacters")
-class GameResultServiceTest extends ServiceTest {
+class GameResultServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private GameResultService gameResultService;

--- a/backend/src/test/java/com/now/naaga/letter/application/LetterServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/letter/application/LetterServiceTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.common.exception.BaseExceptionType;
 import com.now.naaga.game.domain.Game;
 import com.now.naaga.game.domain.GameStatus;
@@ -35,7 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @SuppressWarnings("NonAsciiCharacters")
-class LetterServiceTest extends ServiceTest {
+class LetterServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private LetterService letterService;

--- a/backend/src/test/java/com/now/naaga/letter/presentation/LetterControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/letter/presentation/LetterControllerTest.java
@@ -12,7 +12,7 @@ import static com.now.naaga.game.exception.GameExceptionType.NOT_EXIST_IN_PROGRE
 import static com.now.naaga.player.exception.PlayerExceptionType.PLAYER_NOT_FOUND;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.common.exception.ExceptionResponse;
 import com.now.naaga.game.domain.Game;
 import com.now.naaga.game.presentation.dto.CoordinateResponse;
@@ -40,7 +40,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @SuppressWarnings("NonAsciiCharacters")
-class LetterControllerTest extends ControllerTest {
+class LetterControllerTest extends MySqlContainerControllerTest {
 
     @Test
     void 주변_쪽지를_모두_조회한다() {

--- a/backend/src/test/java/com/now/naaga/like/application/PlaceLikeServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/like/application/PlaceLikeServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.common.exception.BaseExceptionType;
 import com.now.naaga.like.application.dto.ApplyLikeCommand;
 import com.now.naaga.like.application.dto.CancelLikeCommand;
@@ -26,7 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @SuppressWarnings("NonAsciiCharacters")
-class PlaceLikeServiceTest extends ServiceTest {
+class PlaceLikeServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private PlaceLikeService placeLikeService;

--- a/backend/src/test/java/com/now/naaga/like/presentation/PlaceLikeControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/like/presentation/PlaceLikeControllerTest.java
@@ -7,7 +7,7 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.common.exception.ExceptionResponse;
 import com.now.naaga.like.domain.MyPlaceLikeType;
 import com.now.naaga.like.domain.PlaceLike;
@@ -30,7 +30,7 @@ import org.springframework.http.MediaType;
 
 
 @SuppressWarnings("NonAsciiCharacters")
-class PlaceLikeControllerTest extends ControllerTest {
+class PlaceLikeControllerTest extends MySqlContainerControllerTest {
 
     @Test
     void 좋아요_등록이_성공하면_201_응답을_반환한다() {

--- a/backend/src/test/java/com/now/naaga/place/application/PlaceServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/place/application/PlaceServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.common.exception.BaseExceptionType;
 import com.now.naaga.common.fixture.PositionFixture;
 import com.now.naaga.place.application.dto.CreatePlaceCommand;
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @SuppressWarnings("NonAsciiCharacters")
-class PlaceServiceTest extends ServiceTest {
+class PlaceServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private PlaceService placeService;

--- a/backend/src/test/java/com/now/naaga/place/application/PlaceStatisticsServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/place/application/PlaceStatisticsServiceTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.common.exception.BaseExceptionType;
 import com.now.naaga.place.application.dto.CreatePlaceStatisticsCommand;
 import com.now.naaga.place.application.dto.FindPlaceStatisticsByPlaceIdCommand;
@@ -21,7 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 @SuppressWarnings("NonAsciiCharacters")
-class PlaceStatisticsServiceTest extends ServiceTest {
+class PlaceStatisticsServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private PlaceStatisticsService placeStatisticsService;

--- a/backend/src/test/java/com/now/naaga/place/presentation/PlaceControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/place/presentation/PlaceControllerTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.place.domain.Place;
 import com.now.naaga.place.presentation.dto.PlaceResponse;
 import io.restassured.RestAssured;
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 
 @SuppressWarnings("NonAsciiCharacters")
-public class PlaceControllerTest extends ControllerTest {
+public class PlaceControllerTest extends MySqlContainerControllerTest {
 
     @Value("${manager.id}")
     private String id;

--- a/backend/src/test/java/com/now/naaga/player/application/PlayerServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/player/application/PlayerServiceTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.member.domain.Member;
 import com.now.naaga.player.application.dto.AddScoreCommand;
 import com.now.naaga.player.application.dto.EditPlayerNicknameCommand;
@@ -14,22 +14,15 @@ import com.now.naaga.player.domain.Player;
 import com.now.naaga.player.domain.Rank;
 import com.now.naaga.player.exception.PlayerException;
 import com.now.naaga.player.exception.PlayerExceptionType;
-import com.now.naaga.player.persistence.repository.PlayerRepository;
 import com.now.naaga.player.presentation.dto.PlayerRequest;
 import com.now.naaga.score.domain.Score;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Profile;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.transaction.annotation.Transactional;
 
-class PlayerServiceTest extends ServiceTest {
+class PlayerServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private PlayerService playerService;

--- a/backend/src/test/java/com/now/naaga/player/presentation/PlayerControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/player/presentation/PlayerControllerTest.java
@@ -2,7 +2,7 @@ package com.now.naaga.player.presentation;
 
 import com.now.naaga.auth.domain.AuthToken;
 import com.now.naaga.auth.infrastructure.AuthType;
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.common.exception.CommonExceptionType;
 import com.now.naaga.common.exception.ExceptionResponse;
 import com.now.naaga.player.domain.Player;
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @SuppressWarnings("NonAsciiCharacters")
-public class PlayerControllerTest extends ControllerTest {
+public class PlayerControllerTest extends MySqlContainerControllerTest {
 
     @Test
     void 닉네임을_변경한다() {

--- a/backend/src/test/java/com/now/naaga/temporaryplace/application/TemporaryPlaceServiceTest.java
+++ b/backend/src/test/java/com/now/naaga/temporaryplace/application/TemporaryPlaceServiceTest.java
@@ -6,13 +6,13 @@ import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.now.naaga.common.ServiceTest;
+import com.now.naaga.common.MySqlContainerServiceTest;
 import com.now.naaga.temporaryplace.domain.TemporaryPlace;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @SuppressWarnings("NonAsciiCharacters")
-class TemporaryPlaceServiceTest extends ServiceTest {
+class TemporaryPlaceServiceTest extends MySqlContainerServiceTest {
 
     @Autowired
     private TemporaryPlaceService temporaryPlaceService;

--- a/backend/src/test/java/com/now/naaga/temporaryplace/presentation/TemporaryPlaceControllerTest.java
+++ b/backend/src/test/java/com/now/naaga/temporaryplace/presentation/TemporaryPlaceControllerTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.now.naaga.common.ControllerTest;
+import com.now.naaga.common.MySqlContainerControllerTest;
 import com.now.naaga.temporaryplace.domain.TemporaryPlace;
 import com.now.naaga.temporaryplace.presentation.dto.TemporaryPlaceResponse;
 import io.restassured.RestAssured;
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 
 @SuppressWarnings("NonAsciiCharacters")
-class TemporaryPlaceControllerTest extends ControllerTest {
+class TemporaryPlaceControllerTest extends MySqlContainerControllerTest {
 
     @Value("${manager.id}")
     private String id;


### PR DESCRIPTION
## 📌 관련 이슈
- closed: #582 

## 🛠️ 작업 내용
- [x] MySQL TestContainers 적용하여 테스트 MySQL 환경에서 할 수 있도록 수정

## 🎯 리뷰 포인트
### 🤔 문제점
> 저희는 지금까지 테스트를 인메모리 DB인 H2를 활용하여 하고 있었습니다.
H2 환경은 실제 프로덕트와 같은 MySQL 환경과는 다른 점이 존재한다.
1. @Transactional(readOnly=true) 같은 옵션이 벤더사마다 다르게 적용된다 [블로그](https://makemepositive.tistory.com/43)
2. 데이터 타입이 다를 수 있다. &rarr; 추후 공간 인덱스 적용할 때 지오메트리 타입을 적용해야함
3. 문법이 다를 수 있다. 네이티브 쿼리 사용할 때 지원을 안할 수 있음 &rarr; 사실 비관적 락 관련해서 걱정돼서 먼저 살펴본건데, SELECT FOR UPDATE는 H2에서도 잘 적용된다고 하더라구요.



### 😳 선택지
> MySQL을 테스트 환경에서 띄우기 위해서는 세가지 방법 정도가 존재했습니다.

#### 1. 로컬에 직접 MySQL을 직접 실행한다
장점 
- MySQL을 직접 설치하든, Docker를 활용하여 띄우든 테스트가 도는 동안 새로 도커를 띄우지 않기 때문에, 불필요한 시간을 사용하지 않는다.
단점
- 팀원들끼리 환경을 맞추기가 어렵다. 
- 포트라던지, Url, username, ... 등을 맞추기 어렵기 때문에 같은 local 프로필을 사용하기가 어렵다. 
- GithubActions같은 환경에서 테스트하기 위해서는 [플러그인](https://github.com/marketplace/actions/setup-mysql)을 사용해서 띄울 수 있지만, 이것은 CI툴을 변경하면 또 변경해야되는 방법이다.
- 해당 DB가 언제 띄워진 것인지 보장이 없기 때문에 내부 데이터가 오염되어있을 수 있다(이것은 truncate을 하기 때문에 지금은 괜찮아 보입니다)

#### 2. DockerFile이나 Docker-Compose를 이용해서 MySQL을 도커로 띄운다.
장점
- DockerFile이나 Docker-Compose 같은 설정 파일로 설정 공유가 가능하다
- DB를 매번 새로 띄우기 때문에, 오염 걱정을하지 않아도 된다.
- GitHubActions의 Ubuntu 환경에서도 바로 적용이 가능하다.
단점
- 도커 컨테이너를 띄우는 데 시간이 오래걸린다.
- 도커 컨테이너의 생명주기를 커맨드 같은것을 이용해서 직접 관리해줘야한다. 

#### 3. Testcontainers 라이브러리를 이용해서 DB를 띄운다.
> Testcontainers는 테스트 환경을 구성하기 위해 독립적인 컨테이너를 관리해주는 라이브러리
데이터베이스, 메시지 브로커, 웹 서버 등의 외부 리소스를 테스트할 때 효과적이라고 합니다.
 
장점
- 위 2번의 장점을 다 공유한다.
- 도커 컨테이너의 생명주기를 직접 관리해줄 필요 없이 테스트가 종료 되면 컨테이너가 자동으로 종료된다.
- 컨테이너에 대한 설정을 JAVA 코드로 할 수 있어서 설정이 편하다.

단점
- 라이브러리 추가가 필요한다.
- Testcontainers 컨테이너를 띄우고 mysql 컨테이너를 실행하기 때문에 속도가 가장 느리다고 볼 수 있다.

#### ‼그래서 뭘하지?
일단은 Testcontainers를 사용해보았습니다.
제 생각엔 테스트를 세팅하기 위해서 테스트 컨테이너 한번을 띄우는 것은 테스트 속도에 엄청나게 영향을 끼치지 않는다고 생각했습니다.
그리고 1번에서의 설명한 단점들이 전부 치명적이라고 생각해서
코드로 설정을 공유할 수 있는 3번을 선택했습니다!!

### 👍 적용

> 적용 대상은 `모두`로 결정하였습니다!

위에서 다룬 문제점 말고 저희가 H2를 사용할 때 추적하지 못하는 부분이 있을것이라 생각했습니다.
그래서 운영 환경과 같은 환경을 구성하기 위해서 MySQL을 이용한 테스트를 DB를 사용하는 테스트에 모두 적용하기로 했습니다.

```mermaid
classDiagram
    AbstractTest <|-- MySqlContainerTest
    AbstractTest <|-- ControllerTest
    AbstractTest <|-- ServiceTest
    MySqlContainerTest <|-- MySqlContainerControllerTest
    MySqlContainerTest <|-- MySqlContainerServiceTest
    class MySqlContainerTest{
        +MySQLContainer mySqlContainer
        +mySqlProperties(Registry registry)
    }
```
그래서 현재는 위에서 보이는 `MySqlContainerServiceTest`와 `MySqlContainerControllerTest`를 테스트들에 상속해놨습니다.

코드 내용은 복잡하지 않아 간단히 설명하면
```java
public abstract class MySqlContainerTest extends AbstractTest {

    static final MySQLContainer<?> mySqlContainer = new MySQLContainer<>("mysql:8.0.35");

    @DynamicPropertySource
    static void mySqlProperties(final DynamicPropertyRegistry registry) {
        mySqlContainer.start();
        registry.add("spring.datasource.url", mySqlContainer::getJdbcUrl);
        registry.add("spring.datasource.username", mySqlContainer::getUsername);
        registry.add("spring.datasource.password", mySqlContainer::getPassword);
        registry.add("spring.datasource.driver-class-name", mySqlContainer::getDriverClassName);
    }
}
```
이 클래스만 보면되는데요.

```java
static final MySQLContainer<?> mySqlContainer = new MySQLContainer<>("mysql:8.0.35");
```
이것은 mysql:8.0.35버전을 통해서 컨테이너를 구성한는 것이구요.

```java
mySqlContainer.start();
```
컨테이너를 실행하겠다는 의미입니다. 이미지를 풀 받고 컨테이너를 실행하는 작업을 하겠죠.
포트번호를 따로 설정해두지 않았는데요. 그럼 이때마다 포트번호가 동적으로 바뀌고 url도 바뀔 수 있겠죠?

```java
    @DynamicPropertySource
    static void mySqlProperties(final DynamicPropertyRegistry registry) {
        mySqlContainer.start();
        registry.add("spring.datasource.url", mySqlContainer::getJdbcUrl);
        registry.add("spring.datasource.username", mySqlContainer::getUsername);
        registry.add("spring.datasource.password", mySqlContainer::getPassword);
        registry.add("spring.datasource.driver-class-name", mySqlContainer::getDriverClassName);
    }
```
그래서 스프링에서 제공하는 동적으로 프로퍼티를 주입해주는 방법을 이용해서 컨테이너에서 url, username, password, drive-class-name을 읽어와서 주입해줍니다.

참쉽죠?

### 😳 다시 고민

처음에는 MySQL 환경에서 테스트를 필요로하는 테스트만 골라서 적용하려했는데요.
하다보니까 모든 테스트를 동일한 환경에서 돌려야겠다는 생각이 들어서 적용범위를 모두로 넓혔습니다.
하지만 테스트 성능이 매우매우 저하됐는데요.
제 로컬 환경이 좋지 않아서 그런것도 있겠지만 테스트 속도가 5초에서 40초 가까이 저하됐습니다.
이번 CI 파이프라인에서도 테스트 속도를 체크해보고 적용범위를 같이 고민해봐야될 것 같아요!!

## ⏳ 작업 시간
추정 시간: 30분
실제 시간: 2시간
이유: 어떤 방법을 선택할지와 공부를 조금 했어용


## 🔗 참고자료

[공식 문서](https://java.testcontainers.org/modules/databases/mysql/)
[공식 예시 레포](https://github.com/testcontainers/testcontainers-java/blob/main/examples/spring-boot/src/test/java/com/example/AbstractIntegrationTest.java)
[딜리셔스 기술 블록](https://dealicious-inc.github.io/2022/01/10/test-containers.html)
